### PR TITLE
fix(foot): use # for comments and strip # prefix from color values

### DIFF
--- a/extras/foot/README.md
+++ b/extras/foot/README.md
@@ -6,7 +6,7 @@
 ### Example
 
 ```ini
-include ~/.config/foot/themes/oasis_lagoon.ini
+include=~/.config/foot/themes/oasis_lagoon.ini
 ```
 
 Or, you can directly use the generated `.ini` file as your main `foot.ini` if you prefer to have a dedicated configuration per theme.

--- a/extras/foot/generate_foot.lua
+++ b/extras/foot/generate_foot.lua
@@ -7,43 +7,47 @@ package.path = package.path .. ";./lua/?.lua;./lua/?/init.lua"
 local Utils = require("oasis.utils")
 local File = require("oasis.lib.file")
 
+local function strip_color_hash(color)
+  return color:gsub("^#", "")
+end
+
 local function generate_foot_theme(name, palette)
   local display_name = Utils.format_display_name(name)
   local is_light = palette.light_mode or false
 
   local lines = {
-    "; extras/foot/oasis_" .. name .. ".ini",
-    "; name: " .. display_name,
-    "; author: uhs-robert",
+    "# extras/foot/oasis_" .. name .. ".ini",
+    "# name: " .. display_name,
+    "# author: uhs-robert",
     "",
     "[colors]",
-    string.format("cursor=%s %s", palette.bg.core, is_light and palette.syntax.statement or palette.theme.cursor),
-    string.format("foreground=%s", palette.fg.core),
-    string.format("background=%s", palette.bg.core),
+    string.format("cursor=%s %s", strip_color_hash(palette.bg.core), strip_color_hash(is_light and palette.syntax.statement or palette.theme.cursor)),
+    string.format("foreground=%s", strip_color_hash(palette.fg.core)),
+    string.format("background=%s", strip_color_hash(palette.bg.core)),
     "",
-    string.format("selection-foreground=%s", palette.fg.core),
-    string.format("selection-background=%s", palette.ui.visual.bg),
+    string.format("selection-foreground=%s", strip_color_hash(palette.fg.core)),
+    string.format("selection-background=%s", strip_color_hash(palette.ui.visual.bg)),
     "",
-    string.format("search-box-no-match=%s %s", palette.ui.search.fg, palette.ui.search.bg),
-    string.format("search-box-match=%s %s", palette.ui.match.fg, palette.ui.match.bg),
+    string.format("search-box-no-match=%s %s", strip_color_hash(palette.ui.search.fg), strip_color_hash(palette.ui.search.bg)),
+    string.format("search-box-match=%s %s", strip_color_hash(palette.ui.match.fg), strip_color_hash(palette.ui.match.bg)),
     "",
-    string.format("urls=%s", palette.ui.dir),
-    string.format("jump-labels=%s %s", palette.ui.match.fg, palette.ui.match.bg),
+    string.format("urls=%s", strip_color_hash(palette.ui.dir)),
+    string.format("jump-labels=%s %s", strip_color_hash(palette.ui.match.fg), strip_color_hash(palette.ui.match.bg)),
     "",
   }
 
   for i = 0, 7 do
-    lines[#lines + 1] = string.format("regular%d=%s", i, palette.terminal["color" .. i])
+    lines[#lines + 1] = string.format("regular%d=%s", i, strip_color_hash(palette.terminal["color" .. i]))
   end
 
   lines[#lines + 1] = ""
 
   for i = 0, 7 do
-    lines[#lines + 1] = string.format("bright%d=%s", i, palette.terminal["color" .. (i + 8)])
+    lines[#lines + 1] = string.format("bright%d=%s", i, strip_color_hash(palette.terminal["color" .. (i + 8)]))
   end
 
-  lines[#lines + 1] = string.format("16=%s", palette.ui.lineNumber)
-  lines[#lines + 1] = string.format("17=%s", palette.syntax.exception)
+  lines[#lines + 1] = string.format("16=%s", strip_color_hash(palette.ui.lineNumber))
+  lines[#lines + 1] = string.format("17=%s", strip_color_hash(palette.syntax.exception))
 
   return table.concat(lines, "\n")
 end

--- a/extras/foot/themes/dark/oasis_abyss_dark.ini
+++ b/extras/foot/themes/dark/oasis_abyss_dark.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_abyss_dark.ini
-; name: Oasis Abyss Dark
-; author: uhs-robert
+# extras/foot/oasis_abyss_dark.ini
+# name: Oasis Abyss Dark
+# author: uhs-robert
 
 [colors]
-cursor=#000000 #F0E68C
-foreground=#F0EBE6
-background=#000000
+cursor=000000 F0E68C
+foreground=F0EBE6
+background=000000
 
-selection-foreground=#F0EBE6
-selection-background=#532E2E
+selection-foreground=F0EBE6
+selection-background=532E2E
 
-search-box-no-match=#F0EBE6 #4D4A42
-search-box-match=#000000 #F0E68C
+search-box-no-match=F0EBE6 4D4A42
+search-box-match=000000 F0E68C
 
-urls=#87CEEB
-jump-labels=#000000 #F0E68C
+urls=87CEEB
+jump-labels=000000 F0E68C
 
-regular0=#000000
-regular1=#FF7979
-regular2=#53D390
-regular3=#F0E68C
-regular4=#81C0FF
-regular5=#C695FF
-regular6=#68C0B6
-regular7=#DDDBD5
+regular0=000000
+regular1=FF7979
+regular2=53D390
+regular3=F0E68C
+regular4=81C0FF
+regular5=C695FF
+regular6=68C0B6
+regular7=DDDBD5
 
-bright0=#605C4D
-bright1=#FFA0A0
-bright2=#96EA7F
-bright3=#F8B471
-bright4=#87CEEB
-bright5=#D2ADFF
-bright6=#8FD1C7
-bright7=#FFF9F2
-16=#FF9633
-17=#D6CE7C
+bright0=605C4D
+bright1=FFA0A0
+bright2=96EA7F
+bright3=F8B471
+bright4=87CEEB
+bright5=D2ADFF
+bright6=8FD1C7
+bright7=FFF9F2
+16=FF9633
+17=D6CE7C

--- a/extras/foot/themes/dark/oasis_cactus_dark.ini
+++ b/extras/foot/themes/dark/oasis_cactus_dark.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_cactus_dark.ini
-; name: Oasis Cactus Dark
-; author: uhs-robert
+# extras/foot/oasis_cactus_dark.ini
+# name: Oasis Cactus Dark
+# author: uhs-robert
 
 [colors]
-cursor=#1C261E #F0E68C
-foreground=#DDF0E5
-background=#1C261E
+cursor=1C261E F0E68C
+foreground=DDF0E5
+background=1C261E
 
-selection-foreground=#DDF0E5
-selection-background=#3C4B3E
+selection-foreground=DDF0E5
+selection-background=3C4B3E
 
-search-box-no-match=#DDF0E5 #532E2E
-search-box-match=#1C261E #FFA0A0
+search-box-no-match=DDF0E5 532E2E
+search-box-match=1C261E FFA0A0
 
-urls=#87CEEB
-jump-labels=#1C261E #FFA0A0
+urls=87CEEB
+jump-labels=1C261E FFA0A0
 
-regular0=#1C261E
-regular1=#FF7979
-regular2=#53D390
-regular3=#F0E68C
-regular4=#81C0FF
-regular5=#C695FF
-regular6=#68C0B6
-regular7=#DDDBD5
+regular0=1C261E
+regular1=FF7979
+regular2=53D390
+regular3=F0E68C
+regular4=81C0FF
+regular5=C695FF
+regular6=68C0B6
+regular7=DDDBD5
 
-bright0=#5B7360
-bright1=#FFA0A0
-bright2=#96EA7F
-bright3=#F8B471
-bright4=#87CEEB
-bright5=#D2ADFF
-bright6=#8FD1C7
-bright7=#FFF9F2
-16=#FF9633
-17=#F39493
+bright0=5B7360
+bright1=FFA0A0
+bright2=96EA7F
+bright3=F8B471
+bright4=87CEEB
+bright5=D2ADFF
+bright6=8FD1C7
+bright7=FFF9F2
+16=FF9633
+17=F39493

--- a/extras/foot/themes/dark/oasis_canyon_dark.ini
+++ b/extras/foot/themes/dark/oasis_canyon_dark.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_canyon_dark.ini
-; name: Oasis Canyon Dark
-; author: uhs-robert
+# extras/foot/oasis_canyon_dark.ini
+# name: Oasis Canyon Dark
+# author: uhs-robert
 
 [colors]
-cursor=#2F1A05 #F0E68C
-foreground=#F8E7D3
-background=#2F1A05
+cursor=2F1A05 F0E68C
+foreground=F8E7D3
+background=2F1A05
 
-selection-foreground=#F8E7D3
-selection-background=#624020
+selection-foreground=F8E7D3
+selection-background=624020
 
-search-box-no-match=#F8E7D3 #1A3D5C
-search-box-match=#2F1A05 #58B8FD
+search-box-no-match=F8E7D3 1A3D5C
+search-box-match=2F1A05 58B8FD
 
-urls=#92D3ED
-jump-labels=#2F1A05 #58B8FD
+urls=92D3ED
+jump-labels=2F1A05 58B8FD
 
-regular0=#2F1A05
-regular1=#FF7979
-regular2=#53D390
-regular3=#F0E68C
-regular4=#81C0FF
-regular5=#C695FF
-regular6=#68C0B6
-regular7=#DDDBD5
+regular0=2F1A05
+regular1=FF7979
+regular2=53D390
+regular3=F0E68C
+regular4=81C0FF
+regular5=C695FF
+regular6=68C0B6
+regular7=DDDBD5
 
-bright0=#8B6043
-bright1=#FFA0A0
-bright2=#96EA7F
-bright3=#F8B471
-bright4=#87CEEB
-bright5=#D2ADFF
-bright6=#8FD1C7
-bright7=#FFF9F2
-16=#FF9633
-17=#F58B8B
+bright0=8B6043
+bright1=FFA0A0
+bright2=96EA7F
+bright3=F8B471
+bright4=87CEEB
+bright5=D2ADFF
+bright6=8FD1C7
+bright7=FFF9F2
+16=FF9633
+17=F58B8B

--- a/extras/foot/themes/dark/oasis_desert_dark.ini
+++ b/extras/foot/themes/dark/oasis_desert_dark.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_desert_dark.ini
-; name: Oasis Desert Dark
-; author: uhs-robert
+# extras/foot/oasis_desert_dark.ini
+# name: Oasis Desert Dark
+# author: uhs-robert
 
 [colors]
-cursor=#262626 #F0E68C
-foreground=#F7EDE1
-background=#262626
+cursor=262626 F0E68C
+foreground=F7EDE1
+background=262626
 
-selection-foreground=#F7EDE1
-selection-background=#433F38
+selection-foreground=F7EDE1
+selection-background=433F38
 
-search-box-no-match=#262626 #345A2B
-search-box-match=#262626 #70D255
+search-box-no-match=262626 345A2B
+search-box-match=262626 70D255
 
-urls=#87CEEB
-jump-labels=#262626 #70D255
+urls=87CEEB
+jump-labels=262626 70D255
 
-regular0=#262626
-regular1=#FF7979
-regular2=#53D390
-regular3=#F0E68C
-regular4=#81C0FF
-regular5=#C695FF
-regular6=#68C0B6
-regular7=#DDDBD5
+regular0=262626
+regular1=FF7979
+regular2=53D390
+regular3=F0E68C
+regular4=81C0FF
+regular5=C695FF
+regular6=68C0B6
+regular7=DDDBD5
 
-bright0=#77725F
-bright1=#FFA0A0
-bright2=#96EA7F
-bright3=#F8B471
-bright4=#87CEEB
-bright5=#D2ADFF
-bright6=#8FD1C7
-bright7=#FFF9F2
-16=#FF9633
-17=#F58B8B
+bright0=77725F
+bright1=FFA0A0
+bright2=96EA7F
+bright3=F8B471
+bright4=87CEEB
+bright5=D2ADFF
+bright6=8FD1C7
+bright7=FFF9F2
+16=FF9633
+17=F58B8B

--- a/extras/foot/themes/dark/oasis_dune_dark.ini
+++ b/extras/foot/themes/dark/oasis_dune_dark.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_dune_dark.ini
-; name: Oasis Dune Dark
-; author: uhs-robert
+# extras/foot/oasis_dune_dark.ini
+# name: Oasis Dune Dark
+# author: uhs-robert
 
 [colors]
-cursor=#2E2620 #F0E68C
-foreground=#E8E5DA
-background=#2E2620
+cursor=2E2620 F0E68C
+foreground=E8E5DA
+background=2E2620
 
-selection-foreground=#E8E5DA
-selection-background=#534A3F
+selection-foreground=E8E5DA
+selection-background=534A3F
 
-search-box-no-match=#2E2620 #345A2B
-search-box-match=#2E2620 #96EA7F
+search-box-no-match=2E2620 345A2B
+search-box-match=2E2620 96EA7F
 
-urls=#87CEEB
-jump-labels=#2E2620 #96EA7F
+urls=87CEEB
+jump-labels=2E2620 96EA7F
 
-regular0=#2E2620
-regular1=#FF7979
-regular2=#53D390
-regular3=#F0E68C
-regular4=#81C0FF
-regular5=#C695FF
-regular6=#68C0B6
-regular7=#DDDBD5
+regular0=2E2620
+regular1=FF7979
+regular2=53D390
+regular3=F0E68C
+regular4=81C0FF
+regular5=C695FF
+regular6=68C0B6
+regular7=DDDBD5
 
-bright0=#826D5A
-bright1=#FFA0A0
-bright2=#96EA7F
-bright3=#F8B471
-bright4=#87CEEB
-bright5=#D2ADFF
-bright6=#8FD1C7
-bright7=#FFF9F2
-16=#FFA34D
-17=#F29B9B
+bright0=826D5A
+bright1=FFA0A0
+bright2=96EA7F
+bright3=F8B471
+bright4=87CEEB
+bright5=D2ADFF
+bright6=8FD1C7
+bright7=FFF9F2
+16=FFA34D
+17=F29B9B

--- a/extras/foot/themes/dark/oasis_lagoon_dark.ini
+++ b/extras/foot/themes/dark/oasis_lagoon_dark.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_lagoon_dark.ini
-; name: Oasis Lagoon Dark
-; author: uhs-robert
+# extras/foot/oasis_lagoon_dark.ini
+# name: Oasis Lagoon Dark
+# author: uhs-robert
 
 [colors]
-cursor=#101825 #F0E68C
-foreground=#D9E6FA
-background=#101825
+cursor=101825 F0E68C
+foreground=D9E6FA
+background=101825
 
-selection-foreground=#D9E6FA
-selection-background=#22385C
+selection-foreground=D9E6FA
+selection-background=22385C
 
-search-box-no-match=#D9E6FA #5A3824
-search-box-match=#101825 #F9A05E
+search-box-no-match=D9E6FA 5A3824
+search-box-match=101825 F9A05E
 
-urls=#87CEEB
-jump-labels=#101825 #F9A05E
+urls=87CEEB
+jump-labels=101825 F9A05E
 
-regular0=#101825
-regular1=#FF7979
-regular2=#53D390
-regular3=#F0E68C
-regular4=#81C0FF
-regular5=#C695FF
-regular6=#68C0B6
-regular7=#DDDBD5
+regular0=101825
+regular1=FF7979
+regular2=53D390
+regular3=F0E68C
+regular4=81C0FF
+regular5=C695FF
+regular6=68C0B6
+regular7=DDDBD5
 
-bright0=#3B6A87
-bright1=#FFA0A0
-bright2=#96EA7F
-bright3=#F8B471
-bright4=#87CEEB
-bright5=#D2ADFF
-bright6=#8FD1C7
-bright7=#FFF9F2
-16=#FF9633
-17=#F78181
+bright0=3B6A87
+bright1=FFA0A0
+bright2=96EA7F
+bright3=F8B471
+bright4=87CEEB
+bright5=D2ADFF
+bright6=8FD1C7
+bright7=FFF9F2
+16=FF9633
+17=F78181

--- a/extras/foot/themes/dark/oasis_midnight_dark.ini
+++ b/extras/foot/themes/dark/oasis_midnight_dark.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_midnight_dark.ini
-; name: Oasis Midnight Dark
-; author: uhs-robert
+# extras/foot/oasis_midnight_dark.ini
+# name: Oasis Midnight Dark
+# author: uhs-robert
 
 [colors]
-cursor=#101418 #F0E68C
-foreground=#F7F4F2
-background=#101418
+cursor=101418 F0E68C
+foreground=F7F4F2
+background=101418
 
-selection-foreground=#F7F4F2
-selection-background=#1C242C
+selection-foreground=F7F4F2
+selection-background=1C242C
 
-search-box-no-match=#F7F4F2 #4D4A42
-search-box-match=#101418 #F0E68C
+search-box-no-match=F7F4F2 4D4A42
+search-box-match=101418 F0E68C
 
-urls=#87CEEB
-jump-labels=#101418 #F0E68C
+urls=87CEEB
+jump-labels=101418 F0E68C
 
-regular0=#101418
-regular1=#FF7979
-regular2=#53D390
-regular3=#F0E68C
-regular4=#81C0FF
-regular5=#C695FF
-regular6=#68C0B6
-regular7=#DDDBD5
+regular0=101418
+regular1=FF7979
+regular2=53D390
+regular3=F0E68C
+regular4=81C0FF
+regular5=C695FF
+regular6=68C0B6
+regular7=DDDBD5
 
-bright0=#4E6578
-bright1=#FFA0A0
-bright2=#96EA7F
-bright3=#F8B471
-bright4=#87CEEB
-bright5=#D2ADFF
-bright6=#8FD1C7
-bright7=#FFF9F2
-16=#FF9633
-17=#D6CE7C
+bright0=4E6578
+bright1=FFA0A0
+bright2=96EA7F
+bright3=F8B471
+bright4=87CEEB
+bright5=D2ADFF
+bright6=8FD1C7
+bright7=FFF9F2
+16=FF9633
+17=D6CE7C

--- a/extras/foot/themes/dark/oasis_mirage_dark.ini
+++ b/extras/foot/themes/dark/oasis_mirage_dark.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_mirage_dark.ini
-; name: Oasis Mirage Dark
-; author: uhs-robert
+# extras/foot/oasis_mirage_dark.ini
+# name: Oasis Mirage Dark
+# author: uhs-robert
 
 [colors]
-cursor=#18252A #F0E68C
-foreground=#DDEFEF
-background=#18252A
+cursor=18252A F0E68C
+foreground=DDEFEF
+background=18252A
 
-selection-foreground=#DDEFEF
-selection-background=#2A3F46
+selection-foreground=DDEFEF
+selection-background=2A3F46
 
-search-box-no-match=#18252A #5A3824
-search-box-match=#18252A #F9A05E
+search-box-no-match=18252A 5A3824
+search-box-match=18252A F9A05E
 
-urls=#87CEEB
-jump-labels=#18252A #F9A05E
+urls=87CEEB
+jump-labels=18252A F9A05E
 
-regular0=#18252A
-regular1=#FF7979
-regular2=#53D390
-regular3=#F0E68C
-regular4=#81C0FF
-regular5=#C695FF
-regular6=#68C0B6
-regular7=#DDDBD5
+regular0=18252A
+regular1=FF7979
+regular2=53D390
+regular3=F0E68C
+regular4=81C0FF
+regular5=C695FF
+regular6=68C0B6
+regular7=DDDBD5
 
-bright0=#587270
-bright1=#FFA0A0
-bright2=#96EA7F
-bright3=#F8B471
-bright4=#87CEEB
-bright5=#D2ADFF
-bright6=#8FD1C7
-bright7=#FFF9F2
-16=#FF9633
-17=#F39493
+bright0=587270
+bright1=FFA0A0
+bright2=96EA7F
+bright3=F8B471
+bright4=87CEEB
+bright5=D2ADFF
+bright6=8FD1C7
+bright7=FFF9F2
+16=FF9633
+17=F39493

--- a/extras/foot/themes/dark/oasis_night_dark.ini
+++ b/extras/foot/themes/dark/oasis_night_dark.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_night_dark.ini
-; name: Oasis Night Dark
-; author: uhs-robert
+# extras/foot/oasis_night_dark.ini
+# name: Oasis Night Dark
+# author: uhs-robert
 
 [colors]
-cursor=#0D0D1A #F0E68C
-foreground=#F7F4E9
-background=#0D0D1A
+cursor=0D0D1A F0E68C
+foreground=F7F4E9
+background=0D0D1A
 
-selection-foreground=#F7F4E9
-selection-background=#3E2F4A
+selection-foreground=F7F4E9
+selection-background=3E2F4A
 
-search-box-no-match=#F7F4E9 #653F73
-search-box-match=#0D0D1A #F0E68C
+search-box-no-match=F7F4E9 653F73
+search-box-match=0D0D1A F0E68C
 
-urls=#87CEEB
-jump-labels=#0D0D1A #F0E68C
+urls=87CEEB
+jump-labels=0D0D1A F0E68C
 
-regular0=#0D0D1A
-regular1=#FF7979
-regular2=#53D390
-regular3=#F0E68C
-regular4=#81C0FF
-regular5=#C695FF
-regular6=#68C0B6
-regular7=#DDDBD5
+regular0=0D0D1A
+regular1=FF7979
+regular2=53D390
+regular3=F0E68C
+regular4=81C0FF
+regular5=C695FF
+regular6=68C0B6
+regular7=DDDBD5
 
-bright0=#5E5D79
-bright1=#FFA0A0
-bright2=#96EA7F
-bright3=#F8B471
-bright4=#87CEEB
-bright5=#D2ADFF
-bright6=#8FD1C7
-bright7=#FFF9F2
-16=#FF9633
-17=#D6CE7C
+bright0=5E5D79
+bright1=FFA0A0
+bright2=96EA7F
+bright3=F8B471
+bright4=87CEEB
+bright5=D2ADFF
+bright6=8FD1C7
+bright7=FFF9F2
+16=FF9633
+17=D6CE7C

--- a/extras/foot/themes/dark/oasis_rose_dark.ini
+++ b/extras/foot/themes/dark/oasis_rose_dark.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_rose_dark.ini
-; name: Oasis Rose Dark
-; author: uhs-robert
+# extras/foot/oasis_rose_dark.ini
+# name: Oasis Rose Dark
+# author: uhs-robert
 
 [colors]
-cursor=#301828 #F0E68C
-foreground=#EDD5E7
-background=#301828
+cursor=301828 F0E68C
+foreground=EDD5E7
+background=301828
 
-selection-foreground=#EDD5E7
-selection-background=#523A4B
+selection-foreground=EDD5E7
+selection-background=523A4B
 
-search-box-no-match=#EDD5E7 #345A2B
-search-box-match=#301828 #96EA7F
+search-box-no-match=EDD5E7 345A2B
+search-box-match=301828 96EA7F
 
-urls=#87CEEB
-jump-labels=#301828 #96EA7F
+urls=87CEEB
+jump-labels=301828 96EA7F
 
-regular0=#301828
-regular1=#FF7979
-regular2=#53D390
-regular3=#F0E68C
-regular4=#81C0FF
-regular5=#C695FF
-regular6=#68C0B6
-regular7=#DDDBD5
+regular0=301828
+regular1=FF7979
+regular2=53D390
+regular3=F0E68C
+regular4=81C0FF
+regular5=C695FF
+regular6=68C0B6
+regular7=DDDBD5
 
-bright0=#816175
-bright1=#FFA0A0
-bright2=#96EA7F
-bright3=#F8B471
-bright4=#87CEEB
-bright5=#D2ADFF
-bright6=#8FD1C7
-bright7=#FFF9F2
-16=#FF9633
-17=#D6CE7C
+bright0=816175
+bright1=FFA0A0
+bright2=96EA7F
+bright3=F8B471
+bright4=87CEEB
+bright5=D2ADFF
+bright6=8FD1C7
+bright7=FFF9F2
+16=FF9633
+17=D6CE7C

--- a/extras/foot/themes/dark/oasis_sol_dark.ini
+++ b/extras/foot/themes/dark/oasis_sol_dark.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_sol_dark.ini
-; name: Oasis Sol Dark
-; author: uhs-robert
+# extras/foot/oasis_sol_dark.ini
+# name: Oasis Sol Dark
+# author: uhs-robert
 
 [colors]
-cursor=#2F1815 #F0E68C
-foreground=#FFE0DA
-background=#2F1815
+cursor=2F1815 F0E68C
+foreground=FFE0DA
+background=2F1815
 
-selection-foreground=#FFE0DA
-selection-background=#4F312B
+selection-foreground=FFE0DA
+selection-background=4F312B
 
-search-box-no-match=#FFE0DA #345A2B
-search-box-match=#2F1815 #96EA7F
+search-box-no-match=FFE0DA 345A2B
+search-box-match=2F1815 96EA7F
 
-urls=#87CEEB
-jump-labels=#2F1815 #96EA7F
+urls=87CEEB
+jump-labels=2F1815 96EA7F
 
-regular0=#2F1815
-regular1=#FF7979
-regular2=#53D390
-regular3=#F0E68C
-regular4=#81C0FF
-regular5=#C695FF
-regular6=#68C0B6
-regular7=#DDDBD5
+regular0=2F1815
+regular1=FF7979
+regular2=53D390
+regular3=F0E68C
+regular4=81C0FF
+regular5=C695FF
+regular6=68C0B6
+regular7=DDDBD5
 
-bright0=#83615B
-bright1=#FFA0A0
-bright2=#96EA7F
-bright3=#F8B471
-bright4=#87CEEB
-bright5=#D2ADFF
-bright6=#8FD1C7
-bright7=#FFF9F2
-16=#FF9633
-17=#D6CE7C
+bright0=83615B
+bright1=FFA0A0
+bright2=96EA7F
+bright3=F8B471
+bright4=87CEEB
+bright5=D2ADFF
+bright6=8FD1C7
+bright7=FFF9F2
+16=FF9633
+17=D6CE7C

--- a/extras/foot/themes/dark/oasis_starlight_dark.ini
+++ b/extras/foot/themes/dark/oasis_starlight_dark.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_starlight_dark.ini
-; name: Oasis Starlight Dark
-; author: uhs-robert
+# extras/foot/oasis_starlight_dark.ini
+# name: Oasis Starlight Dark
+# author: uhs-robert
 
 [colors]
-cursor=#000000 #F0E68C
-foreground=#FAF7F0
-background=#000000
+cursor=000000 F0E68C
+foreground=FAF7F0
+background=000000
 
-selection-foreground=#FAF7F0
-selection-background=#4D4528
+selection-foreground=FAF7F0
+selection-background=4D4528
 
-search-box-no-match=#FAF7F0 #4D4528
-search-box-match=#000000 #F0E68C
+search-box-no-match=FAF7F0 4D4528
+search-box-match=000000 F0E68C
 
-urls=#87CEEB
-jump-labels=#000000 #F0E68C
+urls=87CEEB
+jump-labels=000000 F0E68C
 
-regular0=#000000
-regular1=#FF7979
-regular2=#53D390
-regular3=#F0E68C
-regular4=#81C0FF
-regular5=#C695FF
-regular6=#68C0B6
-regular7=#DDDBD5
+regular0=000000
+regular1=FF7979
+regular2=53D390
+regular3=F0E68C
+regular4=81C0FF
+regular5=C695FF
+regular6=68C0B6
+regular7=DDDBD5
 
-bright0=#4F5B6B
-bright1=#FFA0A0
-bright2=#96EA7F
-bright3=#F8B471
-bright4=#87CEEB
-bright5=#D2ADFF
-bright6=#8FD1C7
-bright7=#FFF9F2
-16=#FF9633
-17=#FF7979
+bright0=4F5B6B
+bright1=FFA0A0
+bright2=96EA7F
+bright3=F8B471
+bright4=87CEEB
+bright5=D2ADFF
+bright6=8FD1C7
+bright7=FFF9F2
+16=FF9633
+17=FF7979

--- a/extras/foot/themes/dark/oasis_twilight_dark.ini
+++ b/extras/foot/themes/dark/oasis_twilight_dark.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_twilight_dark.ini
-; name: Oasis Twilight Dark
-; author: uhs-robert
+# extras/foot/oasis_twilight_dark.ini
+# name: Oasis Twilight Dark
+# author: uhs-robert
 
 [colors]
-cursor=#221B2F #F0E68C
-foreground=#E6E0F8
-background=#221B2F
+cursor=221B2F F0E68C
+foreground=E6E0F8
+background=221B2F
 
-selection-foreground=#E6E0F8
-selection-background=#352D47
+selection-foreground=E6E0F8
+selection-background=352D47
 
-search-box-no-match=#E6E0F8 #4D4528
-search-box-match=#221B2F #F2E898
+search-box-no-match=E6E0F8 4D4528
+search-box-match=221B2F F2E898
 
-urls=#87CEEB
-jump-labels=#221B2F #F2E898
+urls=87CEEB
+jump-labels=221B2F F2E898
 
-regular0=#221B2F
-regular1=#FF7979
-regular2=#53D390
-regular3=#F0E68C
-regular4=#81C0FF
-regular5=#C695FF
-regular6=#68C0B6
-regular7=#DDDBD5
+regular0=221B2F
+regular1=FF7979
+regular2=53D390
+regular3=F0E68C
+regular4=81C0FF
+regular5=C695FF
+regular6=68C0B6
+regular7=DDDBD5
 
-bright0=#71609A
-bright1=#FFA0A0
-bright2=#96EA7F
-bright3=#F8B471
-bright4=#87CEEB
-bright5=#D2ADFF
-bright6=#8FD1C7
-bright7=#FFF9F2
-16=#FF9633
-17=#F58B8B
+bright0=71609A
+bright1=FFA0A0
+bright2=96EA7F
+bright3=F8B471
+bright4=87CEEB
+bright5=D2ADFF
+bright6=8FD1C7
+bright7=FFF9F2
+16=FF9633
+17=F58B8B

--- a/extras/foot/themes/light/1/oasis_abyss_light_1.ini
+++ b/extras/foot/themes/light/1/oasis_abyss_light_1.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_abyss_light_1.ini
-; name: Oasis Abyss Light 1
-; author: uhs-robert
+# extras/foot/oasis_abyss_light_1.ini
+# name: Oasis Abyss Light 1
+# author: uhs-robert
 
 [colors]
-cursor=#f9f7f5 #bc2126
-foreground=#5c534b
-background=#f9f7f5
+cursor=f9f7f5 bc2126
+foreground=5c534b
+background=f9f7f5
 
-selection-foreground=#5c534b
-selection-background=#e8e0d8
+selection-foreground=5c534b
+selection-background=e8e0d8
 
-search-box-no-match=#4e0e0e #e19d9d
-search-box-match=#0d311d #7ad1a1
+search-box-no-match=4e0e0e e19d9d
+search-box-match=0d311d 7ad1a1
 
-urls=#2d5a6c
-jump-labels=#0d311d #7ad1a1
+urls=2d5a6c
+jump-labels=0d311d 7ad1a1
 
-regular0=#555555
-regular1=#c21313
-regular2=#306c4c
-regular3=#696223
-regular4=#1662af
-regular5=#8030de
-regular6=#366a64
-regular7=#58554c
+regular0=555555
+regular1=c21313
+regular2=306c4c
+regular3=696223
+regular4=1662af
+regular5=8030de
+regular6=366a64
+regular7=58554c
 
-bright0=#5f5349
-bright1=#c21313
-bright2=#366d27
-bright3=#8f5215
-bright4=#266884
-bright5=#7f31de
-bright6=#356a62
-bright7=#7d490c
-16=#79491c
-17=#6a622c
+bright0=5f5349
+bright1=c21313
+bright2=366d27
+bright3=8f5215
+bright4=266884
+bright5=7f31de
+bright6=356a62
+bright7=7d490c
+16=79491c
+17=6a622c

--- a/extras/foot/themes/light/1/oasis_cactus_light_1.ini
+++ b/extras/foot/themes/light/1/oasis_cactus_light_1.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_cactus_light_1.ini
-; name: Oasis Cactus Light 1
-; author: uhs-robert
+# extras/foot/oasis_cactus_light_1.ini
+# name: Oasis Cactus Light 1
+# author: uhs-robert
 
 [colors]
-cursor=#f9fbfa #406d42
-foreground=#465b4f
-background=#f9fbfa
+cursor=f9fbfa 406d42
+foreground=465b4f
+background=f9fbfa
 
-selection-foreground=#465b4f
-selection-background=#dde9e3
+selection-foreground=465b4f
+selection-background=dde9e3
 
-search-box-no-match=#15472f #a4dac0
-search-box-match=#350808 #dd6f6f
+search-box-no-match=15472f a4dac0
+search-box-match=350808 dd6f6f
 
-urls=#2e5c6f
-jump-labels=#350808 #dd6f6f
+urls=2e5c6f
+jump-labels=350808 dd6f6f
 
-regular0=#575757
-regular1=#c51414
-regular2=#306e4e
-regular3=#6b6424
-regular4=#1664b2
-regular5=#8233de
-regular6=#376b66
-regular7=#59564e
+regular0=575757
+regular1=c51414
+regular2=306e4e
+regular3=6b6424
+regular4=1664b2
+regular5=8233de
+regular6=376b66
+regular7=59564e
 
-bright0=#61544b
-bright1=#c51414
-bright2=#376f28
-bright3=#925416
-bright4=#266a86
-bright5=#8134de
-bright6=#366c63
-bright7=#7f4a0d
-16=#7c4b1d
-17=#bb292d
+bright0=61544b
+bright1=c51414
+bright2=376f28
+bright3=925416
+bright4=266a86
+bright5=8134de
+bright6=366c63
+bright7=7f4a0d
+16=7c4b1d
+17=bb292d

--- a/extras/foot/themes/light/1/oasis_canyon_light_1.ini
+++ b/extras/foot/themes/light/1/oasis_canyon_light_1.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_canyon_light_1.ini
-; name: Oasis Canyon Light 1
-; author: uhs-robert
+# extras/foot/oasis_canyon_light_1.ini
+# name: Oasis Canyon Light 1
+# author: uhs-robert
 
 [colors]
-cursor=#f9f7f5 #954f10
-foreground=#665137
-background=#f9f7f5
+cursor=f9f7f5 954f10
+foreground=665137
+background=f9f7f5
 
-selection-foreground=#665137
-selection-background=#e8e0d8
+selection-foreground=665137
+selection-background=e8e0d8
 
-search-box-no-match=#4e260e #e1b69d
-search-box-match=#092234 #72aeda
+search-box-no-match=4e260e e1b69d
+search-box-match=092234 72aeda
 
-urls=#2c5a6d
-jump-labels=#092234 #72aeda
+urls=2c5a6d
+jump-labels=092234 72aeda
 
-regular0=#555555
-regular1=#c21313
-regular2=#306c4c
-regular3=#696223
-regular4=#1662af
-regular5=#8030de
-regular6=#366a64
-regular7=#58554c
+regular0=555555
+regular1=c21313
+regular2=306c4c
+regular3=696223
+regular4=1662af
+regular5=8030de
+regular6=366a64
+regular7=58554c
 
-bright0=#5f5349
-bright1=#c21313
-bright2=#366d27
-bright3=#8f5215
-bright4=#266884
-bright5=#7f31de
-bright6=#356a62
-bright7=#7d490c
-16=#79491c
-17=#ba252a
+bright0=5f5349
+bright1=c21313
+bright2=366d27
+bright3=8f5215
+bright4=266884
+bright5=7f31de
+bright6=356a62
+bright7=7d490c
+16=79491c
+17=ba252a

--- a/extras/foot/themes/light/1/oasis_desert_light_1.ini
+++ b/extras/foot/themes/light/1/oasis_desert_light_1.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_desert_light_1.ini
-; name: Oasis Desert Light 1
-; author: uhs-robert
+# extras/foot/oasis_desert_light_1.ini
+# name: Oasis Desert Light 1
+# author: uhs-robert
 
 [colors]
-cursor=#f9f7f5 #6d6119
-foreground=#63523d
-background=#f9f7f5
+cursor=f9f7f5 6d6119
+foreground=63523d
+background=f9f7f5
 
-selection-foreground=#63523d
-selection-background=#e8e0d8
+selection-foreground=63523d
+selection-background=e8e0d8
 
-search-box-no-match=#473c15 #dacfa4
-search-box-match=#351908 #dd986f
+search-box-no-match=473c15 dacfa4
+search-box-match=351908 dd986f
 
-urls=#2d5a6c
-jump-labels=#351908 #dd986f
+urls=2d5a6c
+jump-labels=351908 dd986f
 
-regular0=#555555
-regular1=#c21313
-regular2=#306c4c
-regular3=#696223
-regular4=#1662af
-regular5=#8030de
-regular6=#366a64
-regular7=#58554c
+regular0=555555
+regular1=c21313
+regular2=306c4c
+regular3=696223
+regular4=1662af
+regular5=8030de
+regular6=366a64
+regular7=58554c
 
-bright0=#5f5349
-bright1=#c21313
-bright2=#366d27
-bright3=#8f5215
-bright4=#266884
-bright5=#7f31de
-bright6=#356a62
-bright7=#7d490c
-16=#79491c
-17=#ba252a
+bright0=5f5349
+bright1=c21313
+bright2=366d27
+bright3=8f5215
+bright4=266884
+bright5=7f31de
+bright6=356a62
+bright7=7d490c
+16=79491c
+17=ba252a

--- a/extras/foot/themes/light/1/oasis_dune_light_1.ini
+++ b/extras/foot/themes/light/1/oasis_dune_light_1.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_dune_light_1.ini
-; name: Oasis Dune Light 1
-; author: uhs-robert
+# extras/foot/oasis_dune_light_1.ini
+# name: Oasis Dune Light 1
+# author: uhs-robert
 
 [colors]
-cursor=#f9f8f5 #6d6219
-foreground=#58554c
-background=#f9f8f5
+cursor=f9f8f5 6d6219
+foreground=58554c
+background=f9f8f5
 
-selection-foreground=#58554c
-selection-background=#e8e4d8
+selection-foreground=58554c
+selection-background=e8e4d8
 
-search-box-no-match=#473c15 #dacfa4
-search-box-match=#210b32 #ab76d6
+search-box-no-match=473c15 dacfa4
+search-box-match=210b32 ab76d6
 
-urls=#2d5b6d
-jump-labels=#210b32 #ab76d6
+urls=2d5b6d
+jump-labels=210b32 ab76d6
 
-regular0=#555555
-regular1=#c21313
-regular2=#306d4d
-regular3=#696323
-regular4=#1662b0
-regular5=#8031de
-regular6=#366a65
-regular7=#58554d
+regular0=555555
+regular1=c21313
+regular2=306d4d
+regular3=696323
+regular4=1662b0
+regular5=8031de
+regular6=366a65
+regular7=58554d
 
-bright0=#5f5349
-bright1=#c21414
-bright2=#366e27
-bright3=#905215
-bright4=#266884
-bright5=#7f32de
-bright6=#366a62
-bright7=#7d490c
-16=#7a4a1d
-17=#b72b30
+bright0=5f5349
+bright1=c21414
+bright2=366e27
+bright3=905215
+bright4=266884
+bright5=7f32de
+bright6=366a62
+bright7=7d490c
+16=7a4a1d
+17=b72b30

--- a/extras/foot/themes/light/1/oasis_lagoon_light_1.ini
+++ b/extras/foot/themes/light/1/oasis_lagoon_light_1.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_lagoon_light_1.ini
-; name: Oasis Lagoon Light 1
-; author: uhs-robert
+# extras/foot/oasis_lagoon_light_1.ini
+# name: Oasis Lagoon Light 1
+# author: uhs-robert
 
 [colors]
-cursor=#f9fafb #1665aa
-foreground=#40577a
-background=#f9fafb
+cursor=f9fafb 1665aa
+foreground=40577a
+background=f9fafb
 
-selection-foreground=#40577a
-selection-background=#dde3e9
+selection-foreground=40577a
+selection-background=dde3e9
 
-search-box-no-match=#0f384c #9fcae0
-search-box-match=#351908 #dd986f
+search-box-no-match=0f384c 9fcae0
+search-box-match=351908 dd986f
 
-urls=#2e5c6e
-jump-labels=#351908 #dd986f
+urls=2e5c6e
+jump-labels=351908 dd986f
 
-regular0=#565656
-regular1=#c51414
-regular2=#306e4e
-regular3=#6a6423
-regular4=#1663b1
-regular5=#8133de
-regular6=#376b65
-regular7=#59564e
+regular0=565656
+regular1=c51414
+regular2=306e4e
+regular3=6a6423
+regular4=1663b1
+regular5=8133de
+regular6=376b65
+regular7=59564e
 
-bright0=#60544a
-bright1=#c41414
-bright2=#376f28
-bright3=#915315
-bright4=#266a86
-bright5=#8033de
-bright6=#366c63
-bright7=#7e4a0d
-16=#7c4b1d
-17=#bf2227
+bright0=60544a
+bright1=c41414
+bright2=376f28
+bright3=915315
+bright4=266a86
+bright5=8033de
+bright6=366c63
+bright7=7e4a0d
+16=7c4b1d
+17=bf2227

--- a/extras/foot/themes/light/1/oasis_midnight_light_1.ini
+++ b/extras/foot/themes/light/1/oasis_midnight_light_1.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_midnight_light_1.ini
-; name: Oasis Midnight Light 1
-; author: uhs-robert
+# extras/foot/oasis_midnight_light_1.ini
+# name: Oasis Midnight Light 1
+# author: uhs-robert
 
 [colors]
-cursor=#f9f6f5 #b9252a
-foreground=#5c534c
-background=#f9f6f5
+cursor=f9f6f5 b9252a
+foreground=5c534c
+background=f9f6f5
 
-selection-foreground=#5c534c
-selection-background=#e8dcd8
+selection-foreground=5c534c
+selection-background=e8dcd8
 
-search-box-no-match=#4e0e0e #e19d9d
-search-box-match=#0d311d #7ad1a1
+search-box-no-match=4e0e0e e19d9d
+search-box-match=0d311d 7ad1a1
 
-urls=#2d5a6c
-jump-labels=#0d311d #7ad1a1
+urls=2d5a6c
+jump-labels=0d311d 7ad1a1
 
-regular0=#545454
-regular1=#c11313
-regular2=#2f6c4c
-regular3=#696223
-regular4=#1661ae
-regular5=#7f2fde
-regular6=#366964
-regular7=#57544c
+regular0=545454
+regular1=c11313
+regular2=2f6c4c
+regular3=696223
+regular4=1661ae
+regular5=7f2fde
+regular6=366964
+regular7=57544c
 
-bright0=#5f5249
-bright1=#c11313
-bright2=#366d27
-bright3=#8e5215
-bright4=#266783
-bright5=#7e30dd
-bright6=#356a61
-bright7=#7c480c
-16=#79491c
-17=#69612c
+bright0=5f5249
+bright1=c11313
+bright2=366d27
+bright3=8e5215
+bright4=266783
+bright5=7e30dd
+bright6=356a61
+bright7=7c480c
+16=79491c
+17=69612c

--- a/extras/foot/themes/light/1/oasis_mirage_light_1.ini
+++ b/extras/foot/themes/light/1/oasis_mirage_light_1.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_mirage_light_1.ini
-; name: Oasis Mirage Light 1
-; author: uhs-robert
+# extras/foot/oasis_mirage_light_1.ini
+# name: Oasis Mirage Light 1
+# author: uhs-robert
 
 [colors]
-cursor=#f9fbfa #356c63
-foreground=#455b5b
-background=#f9fbfa
+cursor=f9fbfa 356c63
+foreground=455b5b
+background=f9fbfa
 
-selection-foreground=#455b5b
-selection-background=#dde9e3
+selection-foreground=455b5b
+selection-background=dde9e3
 
-search-box-no-match=#0f4c44 #9fe0d7
-search-box-match=#351908 #dd986f
+search-box-no-match=0f4c44 9fe0d7
+search-box-match=351908 dd986f
 
-urls=#2e5c6f
-jump-labels=#351908 #dd986f
+urls=2e5c6f
+jump-labels=351908 dd986f
 
-regular0=#575757
-regular1=#c51414
-regular2=#306e4e
-regular3=#6b6424
-regular4=#1664b2
-regular5=#8233de
-regular6=#376b66
-regular7=#59564e
+regular0=575757
+regular1=c51414
+regular2=306e4e
+regular3=6b6424
+regular4=1664b2
+regular5=8233de
+regular6=376b66
+regular7=59564e
 
-bright0=#61544b
-bright1=#c51414
-bright2=#376f28
-bright3=#925416
-bright4=#266a86
-bright5=#8134de
-bright6=#366c63
-bright7=#7f4a0d
-16=#7c4b1d
-17=#bb292d
+bright0=61544b
+bright1=c51414
+bright2=376f28
+bright3=925416
+bright4=266a86
+bright5=8134de
+bright6=366c63
+bright7=7f4a0d
+16=7c4b1d
+17=bb292d

--- a/extras/foot/themes/light/1/oasis_night_light_1.ini
+++ b/extras/foot/themes/light/1/oasis_night_light_1.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_night_light_1.ini
-; name: Oasis Night Light 1
-; author: uhs-robert
+# extras/foot/oasis_night_light_1.ini
+# name: Oasis Night Light 1
+# author: uhs-robert
 
 [colors]
-cursor=#e0dbcc #7b410d
-foreground=#52422d
-background=#e0dbcc
+cursor=e0dbcc 7b410d
+foreground=52422d
+background=e0dbcc
 
-selection-foreground=#52422d
-selection-background=#cfc7af
+selection-foreground=52422d
+selection-background=cfc7af
 
-search-box-no-match=#4e260e #e1b69d
-search-box-match=#350808 #dd6f6f
+search-box-no-match=4e260e e1b69d
+search-box-match=350808 dd6f6f
 
-urls=#244958
-jump-labels=#350808 #dd6f6f
+urls=244958
+jump-labels=350808 dd6f6f
 
-regular0=#623b14
-regular1=#a21010
-regular2=#275a3f
-regular3=#57511d
-regular4=#125191
-regular5=#6b1fc4
-regular6=#2d5753
-regular7=#47443e
+regular0=623b14
+regular1=a21010
+regular2=275a3f
+regular3=57511d
+regular4=125191
+regular5=6b1fc4
+regular6=2d5753
+regular7=47443e
 
-bright0=#574030
-bright1=#a21010
-bright2=#2d5b20
-bright3=#764412
-bright4=#1f566d
-bright5=#6a20c4
-bright6=#2c5851
-bright7=#653b0a
-16=#623b17
-17=#9b1f23
+bright0=574030
+bright1=a21010
+bright2=2d5b20
+bright3=764412
+bright4=1f566d
+bright5=6a20c4
+bright6=2c5851
+bright7=653b0a
+16=623b17
+17=9b1f23

--- a/extras/foot/themes/light/1/oasis_rose_light_1.ini
+++ b/extras/foot/themes/light/1/oasis_rose_light_1.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_rose_light_1.ini
-; name: Oasis Rose Light 1
-; author: uhs-robert
+# extras/foot/oasis_rose_light_1.ini
+# name: Oasis Rose Light 1
+# author: uhs-robert
 
 [colors]
-cursor=#fbf9fb #c3151c
-foreground=#694e63
-background=#fbf9fb
+cursor=fbf9fb c3151c
+foreground=694e63
+background=fbf9fb
 
-selection-foreground=#694e63
-selection-background=#e9dde9
+selection-foreground=694e63
+selection-background=e9dde9
 
-search-box-no-match=#481335 #dba3c6
-search-box-match=#09342f #72dacc
+search-box-no-match=481335 dba3c6
+search-box-match=09342f 72dacc
 
-urls=#2e5c6e
-jump-labels=#09342f #72dacc
+urls=2e5c6e
+jump-labels=09342f 72dacc
 
-regular0=#565656
-regular1=#c41414
-regular2=#306e4d
-regular3=#6a6423
-regular4=#1663b1
-regular5=#8132de
-regular6=#376b65
-regular7=#59564d
+regular0=565656
+regular1=c41414
+regular2=306e4d
+regular3=6a6423
+regular4=1663b1
+regular5=8132de
+regular6=376b65
+regular7=59564d
 
-bright0=#60544a
-bright1=#c41414
-bright2=#376f28
-bright3=#915315
-bright4=#266985
-bright5=#8033de
-bright6=#366b63
-bright7=#7e4a0d
-16=#7c4b1d
-17=#6b632c
+bright0=60544a
+bright1=c41414
+bright2=376f28
+bright3=915315
+bright4=266985
+bright5=8033de
+bright6=366b63
+bright7=7e4a0d
+16=7c4b1d
+17=6b632c

--- a/extras/foot/themes/light/1/oasis_sol_light_1.ini
+++ b/extras/foot/themes/light/1/oasis_sol_light_1.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_sol_light_1.ini
-; name: Oasis Sol Light 1
-; author: uhs-robert
+# extras/foot/oasis_sol_light_1.ini
+# name: Oasis Sol Light 1
+# author: uhs-robert
 
 [colors]
-cursor=#f9f5f5 #b6282c
-foreground=#814236
-background=#f9f5f5
+cursor=f9f5f5 b6282c
+foreground=814236
+background=f9f5f5
 
-selection-foreground=#814236
-selection-background=#e8d8d8
+selection-foreground=814236
+selection-background=e8d8d8
 
-search-box-no-match=#4e0e0e #e19d9d
-search-box-match=#0d311f #7ad1a7
+search-box-no-match=4e0e0e e19d9d
+search-box-match=0d311f 7ad1a7
 
-urls=#2d5a6c
-jump-labels=#0d311f #7ad1a7
+urls=2d5a6c
+jump-labels=0d311f 7ad1a7
 
-regular0=#545454
-regular1=#c01313
-regular2=#2f6b4c
-regular3=#686223
-regular4=#1561ad
-regular5=#7f2fdd
-regular6=#366963
-regular7=#57544c
+regular0=545454
+regular1=c01313
+regular2=2f6b4c
+regular3=686223
+regular4=1561ad
+regular5=7f2fdd
+regular6=366963
+regular7=57544c
 
-bright0=#5e5248
-bright1=#c01313
-bright2=#366c27
-bright3=#8e5115
-bright4=#256782
-bright5=#7e2fdd
-bright6=#356961
-bright7=#7b480c
-16=#78491c
-17=#69612c
+bright0=5e5248
+bright1=c01313
+bright2=366c27
+bright3=8e5115
+bright4=256782
+bright5=7e2fdd
+bright6=356961
+bright7=7b480c
+16=78491c
+17=69612c

--- a/extras/foot/themes/light/1/oasis_starlight_light_1.ini
+++ b/extras/foot/themes/light/1/oasis_starlight_light_1.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_starlight_light_1.ini
-; name: Oasis Starlight Light 1
-; author: uhs-robert
+# extras/foot/oasis_starlight_light_1.ini
+# name: Oasis Starlight Light 1
+# author: uhs-robert
 
 [colors]
-cursor=#f9f7f5 #1563a7
-foreground=#5c5442
-background=#f9f7f5
+cursor=f9f7f5 1563a7
+foreground=5c5442
+background=f9f7f5
 
-selection-foreground=#5c5442
-selection-background=#e8e0d8
+selection-foreground=5c5442
+selection-background=e8e0d8
 
-search-box-no-match=#473c15 #dacfa4
-search-box-match=#351908 #dd986f
+search-box-no-match=473c15 dacfa4
+search-box-match=351908 dd986f
 
-urls=#2d5a6c
-jump-labels=#351908 #dd986f
+urls=2d5a6c
+jump-labels=351908 dd986f
 
-regular0=#555555
-regular1=#c21313
-regular2=#306c4c
-regular3=#696223
-regular4=#1662af
-regular5=#8030de
-regular6=#366a64
-regular7=#58554c
+regular0=555555
+regular1=c21313
+regular2=306c4c
+regular3=696223
+regular4=1662af
+regular5=8030de
+regular6=366a64
+regular7=58554c
 
-bright0=#5f5349
-bright1=#c21313
-bright2=#366d27
-bright3=#8f5215
-bright4=#266884
-bright5=#7f31de
-bright6=#356a62
-bright7=#7d490c
-16=#79491c
-17=#c1151c
+bright0=5f5349
+bright1=c21313
+bright2=366d27
+bright3=8f5215
+bright4=266884
+bright5=7f31de
+bright6=356a62
+bright7=7d490c
+16=79491c
+17=c1151c

--- a/extras/foot/themes/light/1/oasis_twilight_light_1.ini
+++ b/extras/foot/themes/light/1/oasis_twilight_light_1.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_twilight_light_1.ini
-; name: Oasis Twilight Light 1
-; author: uhs-robert
+# extras/foot/oasis_twilight_light_1.ini
+# name: Oasis Twilight Light 1
+# author: uhs-robert
 
 [colors]
-cursor=#f9f9fb #8724e7
-foreground=#5b4f7e
-background=#f9f9fb
+cursor=f9f9fb 8724e7
+foreground=5b4f7e
+background=f9f9fb
 
-selection-foreground=#5b4f7e
-selection-background=#dddde9
+selection-foreground=5b4f7e
+selection-background=dddde9
 
-search-box-no-match=#31124a #c3a1dd
-search-box-match=#31290d #d1be7a
+search-box-no-match=31124a c3a1dd
+search-box-match=31290d d1be7a
 
-urls=#2e5b6e
-jump-labels=#31290d #d1be7a
+urls=2e5b6e
+jump-labels=31290d d1be7a
 
-regular0=#565656
-regular1=#c41414
-regular2=#306d4d
-regular3=#6a6323
-regular4=#1663b1
-regular5=#8132de
-regular6=#376b65
-regular7=#59564d
+regular0=565656
+regular1=c41414
+regular2=306d4d
+regular3=6a6323
+regular4=1663b1
+regular5=8132de
+regular6=376b65
+regular7=59564d
 
-bright0=#60544a
-bright1=#c41414
-bright2=#376e28
-bright3=#905315
-bright4=#266985
-bright5=#8033de
-bright6=#366b63
-bright7=#7e490d
-16=#7b4a1d
-17=#bc252a
+bright0=60544a
+bright1=c41414
+bright2=376e28
+bright3=905315
+bright4=266985
+bright5=8033de
+bright6=366b63
+bright7=7e490d
+16=7b4a1d
+17=bc252a

--- a/extras/foot/themes/light/2/oasis_abyss_light_2.ini
+++ b/extras/foot/themes/light/2/oasis_abyss_light_2.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_abyss_light_2.ini
-; name: Oasis Abyss Light 2
-; author: uhs-robert
+# extras/foot/oasis_abyss_light_2.ini
+# name: Oasis Abyss Light 2
+# author: uhs-robert
 
 [colors]
-cursor=#f8f0e7 #b61f25
-foreground=#585048
-background=#f8f0e7
+cursor=f8f0e7 b61f25
+foreground=585048
+background=f8f0e7
 
-selection-foreground=#585048
-selection-background=#eedac3
+selection-foreground=585048
+selection-background=eedac3
 
-search-box-no-match=#4e0e0e #e19d9d
-search-box-match=#0d311d #7ad1a1
+search-box-no-match=4e0e0e e19d9d
+search-box-match=0d311d 7ad1a1
 
-urls=#2b5768
-jump-labels=#0d311d #7ad1a1
+urls=2b5768
+jump-labels=0d311d 7ad1a1
 
-regular0=#515151
-regular1=#bb1313
-regular2=#2f6849
-regular3=#655f22
-regular4=#155ea9
-regular5=#7c2adc
-regular6=#346660
-regular7=#545149
+regular0=515151
+regular1=bb1313
+regular2=2f6849
+regular3=655f22
+regular4=155ea9
+regular5=7c2adc
+regular6=346660
+regular7=545149
 
-bright0=#5b4f47
-bright1=#bb1313
-bright2=#356926
-bright3=#8a4f14
-bright4=#24647e
-bright5=#7a2bdc
-bright6=#34665f
-bright7=#77450c
-16=#74471b
-17=#655e2a
+bright0=5b4f47
+bright1=bb1313
+bright2=356926
+bright3=8a4f14
+bright4=24647e
+bright5=7a2bdc
+bright6=34665f
+bright7=77450c
+16=74471b
+17=655e2a

--- a/extras/foot/themes/light/2/oasis_cactus_light_2.ini
+++ b/extras/foot/themes/light/2/oasis_cactus_light_2.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_cactus_light_2.ini
-; name: Oasis Cactus Light 2
-; author: uhs-robert
+# extras/foot/oasis_cactus_light_2.ini
+# name: Oasis Cactus Light 2
+# author: uhs-robert
 
 [colors]
-cursor=#eef7f2 #3e6940
-foreground=#44584c
-background=#eef7f2
+cursor=eef7f2 3e6940
+foreground=44584c
+background=eef7f2
 
-selection-foreground=#44584c
-selection-background=#cfe8da
+selection-foreground=44584c
+selection-background=cfe8da
 
-search-box-no-match=#15472f #a4dac0
-search-box-match=#350808 #dd6f6f
+search-box-no-match=15472f a4dac0
+search-box-match=350808 dd6f6f
 
-urls=#2c596b
-jump-labels=#350808 #dd6f6f
+urls=2c596b
+jump-labels=350808 dd6f6f
 
-regular0=#535353
-regular1=#bf1313
-regular2=#306b4b
-regular3=#686123
-regular4=#1560ad
-regular5=#7e2ddc
-regular6=#356862
-regular7=#56534b
+regular0=535353
+regular1=bf1313
+regular2=306b4b
+regular3=686123
+regular4=1560ad
+regular5=7e2ddc
+regular6=356862
+regular7=56534b
 
-bright0=#5e5149
-bright1=#bf1313
-bright2=#366b27
-bright3=#8d5115
-bright4=#256681
-bright5=#7d2fdd
-bright6=#356861
-bright7=#7a470c
-16=#77481c
-17=#b5282c
+bright0=5e5149
+bright1=bf1313
+bright2=366b27
+bright3=8d5115
+bright4=256681
+bright5=7d2fdd
+bright6=356861
+bright7=7a470c
+16=77481c
+17=b5282c

--- a/extras/foot/themes/light/2/oasis_canyon_light_2.ini
+++ b/extras/foot/themes/light/2/oasis_canyon_light_2.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_canyon_light_2.ini
-; name: Oasis Canyon Light 2
-; author: uhs-robert
+# extras/foot/oasis_canyon_light_2.ini
+# name: Oasis Canyon Light 2
+# author: uhs-robert
 
 [colors]
-cursor=#f8f0e7 #8f4c10
-foreground=#624e35
-background=#f8f0e7
+cursor=f8f0e7 8f4c10
+foreground=624e35
+background=f8f0e7
 
-selection-foreground=#624e35
-selection-background=#eedac3
+selection-foreground=624e35
+selection-background=eedac3
 
-search-box-no-match=#4e260e #e1b69d
-search-box-match=#092234 #72aeda
+search-box-no-match=4e260e e1b69d
+search-box-match=092234 72aeda
 
-urls=#2a5768
-jump-labels=#092234 #72aeda
+urls=2a5768
+jump-labels=092234 72aeda
 
-regular0=#515151
-regular1=#bb1313
-regular2=#2f6849
-regular3=#655f22
-regular4=#155ea9
-regular5=#7c2adc
-regular6=#346660
-regular7=#545149
+regular0=515151
+regular1=bb1313
+regular2=2f6849
+regular3=655f22
+regular4=155ea9
+regular5=7c2adc
+regular6=346660
+regular7=545149
 
-bright0=#5b4f47
-bright1=#bb1313
-bright2=#356926
-bright3=#8a4f14
-bright4=#24647e
-bright5=#7a2bdc
-bright6=#34665f
-bright7=#77450c
-16=#74471b
-17=#b42329
+bright0=5b4f47
+bright1=bb1313
+bright2=356926
+bright3=8a4f14
+bright4=24647e
+bright5=7a2bdc
+bright6=34665f
+bright7=77450c
+16=74471b
+17=b42329

--- a/extras/foot/themes/light/2/oasis_desert_light_2.ini
+++ b/extras/foot/themes/light/2/oasis_desert_light_2.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_desert_light_2.ini
-; name: Oasis Desert Light 2
-; author: uhs-robert
+# extras/foot/oasis_desert_light_2.ini
+# name: Oasis Desert Light 2
+# author: uhs-robert
 
 [colors]
-cursor=#f8f0e7 #695e19
-foreground=#5f4e3b
-background=#f8f0e7
+cursor=f8f0e7 695e19
+foreground=5f4e3b
+background=f8f0e7
 
-selection-foreground=#5f4e3b
-selection-background=#eedac3
+selection-foreground=5f4e3b
+selection-background=eedac3
 
-search-box-no-match=#473c15 #dacfa4
-search-box-match=#351908 #dd986f
+search-box-no-match=473c15 dacfa4
+search-box-match=351908 dd986f
 
-urls=#2b5768
-jump-labels=#351908 #dd986f
+urls=2b5768
+jump-labels=351908 dd986f
 
-regular0=#515151
-regular1=#bb1313
-regular2=#2f6849
-regular3=#655f22
-regular4=#155ea9
-regular5=#7c2adc
-regular6=#346660
-regular7=#545149
+regular0=515151
+regular1=bb1313
+regular2=2f6849
+regular3=655f22
+regular4=155ea9
+regular5=7c2adc
+regular6=346660
+regular7=545149
 
-bright0=#5b4f47
-bright1=#bb1313
-bright2=#356926
-bright3=#8a4f14
-bright4=#24647e
-bright5=#7a2bdc
-bright6=#34665f
-bright7=#77450c
-16=#74471b
-17=#b42329
+bright0=5b4f47
+bright1=bb1313
+bright2=356926
+bright3=8a4f14
+bright4=24647e
+bright5=7a2bdc
+bright6=34665f
+bright7=77450c
+16=74471b
+17=b42329

--- a/extras/foot/themes/light/2/oasis_dune_light_2.ini
+++ b/extras/foot/themes/light/2/oasis_dune_light_2.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_dune_light_2.ini
-; name: Oasis Dune Light 2
-; author: uhs-robert
+# extras/foot/oasis_dune_light_2.ini
+# name: Oasis Dune Light 2
+# author: uhs-robert
 
 [colors]
-cursor=#f9f6ec #6b611a
-foreground=#57544b
-background=#f9f6ec
+cursor=f9f6ec 6b611a
+foreground=57544b
+background=f9f6ec
 
-selection-foreground=#57544b
-selection-background=#eee5c9
+selection-foreground=57544b
+selection-background=eee5c9
 
-search-box-no-match=#473c15 #dacfa4
-search-box-match=#210b32 #ab76d6
+search-box-no-match=473c15 dacfa4
+search-box-match=210b32 ab76d6
 
-urls=#2d5a6c
-jump-labels=#210b32 #ab76d6
+urls=2d5a6c
+jump-labels=210b32 ab76d6
 
-regular0=#545454
-regular1=#c01313
-regular2=#306b4c
-regular3=#686123
-regular4=#1561ad
-regular5=#7f2fdd
-regular6=#366963
-regular7=#57544b
+regular0=545454
+regular1=c01313
+regular2=306b4c
+regular3=686123
+regular4=1561ad
+regular5=7f2fdd
+regular6=366963
+regular7=57544b
 
-bright0=#5e5249
-bright1=#c01313
-bright2=#366c27
-bright3=#8e5115
-bright4=#256782
-bright5=#7e30dd
-bright6=#356961
-bright7=#7b480c
-16=#78491c
-17=#b42c2f
+bright0=5e5249
+bright1=c01313
+bright2=366c27
+bright3=8e5115
+bright4=256782
+bright5=7e30dd
+bright6=356961
+bright7=7b480c
+16=78491c
+17=b42c2f

--- a/extras/foot/themes/light/2/oasis_lagoon_light_2.ini
+++ b/extras/foot/themes/light/2/oasis_lagoon_light_2.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_lagoon_light_2.ini
-; name: Oasis Lagoon Light 2
-; author: uhs-robert
+# extras/foot/oasis_lagoon_light_2.ini
+# name: Oasis Lagoon Light 2
+# author: uhs-robert
 
 [colors]
-cursor=#ebf1f9 #135fa2
-foreground=#3d5273
-background=#ebf1f9
+cursor=ebf1f9 135fa2
+foreground=3d5273
+background=ebf1f9
 
-selection-foreground=#3d5273
-selection-background=#c8d8ee
+selection-foreground=3d5273
+selection-background=c8d8ee
 
-search-box-no-match=#0f384c #9fcae0
-search-box-match=#351908 #dd986f
+search-box-no-match=0f384c 9fcae0
+search-box-match=351908 dd986f
 
-urls=#2b5668
-jump-labels=#351908 #dd986f
+urls=2b5668
+jump-labels=351908 dd986f
 
-regular0=#515151
-regular1=#ba1313
-regular2=#2f6849
-regular3=#655e22
-regular4=#155ea8
-regular5=#7b29dc
-regular6=#34655f
-regular7=#535148
+regular0=515151
+regular1=ba1313
+regular2=2f6849
+regular3=655e22
+regular4=155ea8
+regular5=7b29dc
+regular6=34655f
+regular7=535148
 
-bright0=#5b4f47
-bright1=#ba1313
-bright2=#346926
-bright3=#894f14
-bright4=#24647e
-bright5=#7a2adc
-bright6=#34655e
-bright7=#77450c
-16=#74461b
-17=#b51f25
+bright0=5b4f47
+bright1=ba1313
+bright2=346926
+bright3=894f14
+bright4=24647e
+bright5=7a2adc
+bright6=34655e
+bright7=77450c
+16=74461b
+17=b51f25

--- a/extras/foot/themes/light/2/oasis_midnight_light_2.ini
+++ b/extras/foot/themes/light/2/oasis_midnight_light_2.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_midnight_light_2.ini
-; name: Oasis Midnight Light 2
-; author: uhs-robert
+# extras/foot/oasis_midnight_light_2.ini
+# name: Oasis Midnight Light 2
+# author: uhs-robert
 
 [colors]
-cursor=#f8eee7 #b22328
-foreground=#584f48
-background=#f8eee7
+cursor=f8eee7 b22328
+foreground=584f48
+background=f8eee7
 
-selection-foreground=#584f48
-selection-background=#eed5c3
+selection-foreground=584f48
+selection-background=eed5c3
 
-search-box-no-match=#4e0e0e #e19d9d
-search-box-match=#0d311d #7ad1a1
+search-box-no-match=4e0e0e e19d9d
+search-box-match=0d311d 7ad1a1
 
-urls=#2b5667
-jump-labels=#0d311d #7ad1a1
+urls=2b5667
+jump-labels=0d311d 7ad1a1
 
-regular0=#505050
-regular1=#b91313
-regular2=#2e6749
-regular3=#655e22
-regular4=#155da7
-regular5=#7b28dc
-regular6=#34655f
-regular7=#535048
+regular0=505050
+regular1=b91313
+regular2=2e6749
+regular3=655e22
+regular4=155da7
+regular5=7b28dc
+regular6=34655f
+regular7=535048
 
-bright0=#5a4e46
-bright1=#b91313
-bright2=#346826
-bright3=#884e14
-bright4=#24637d
-bright5=#7929dc
-bright6=#33655e
-bright7=#76450c
-16=#73461b
-17=#645d2a
+bright0=5a4e46
+bright1=b91313
+bright2=346826
+bright3=884e14
+bright4=24637d
+bright5=7929dc
+bright6=33655e
+bright7=76450c
+16=73461b
+17=645d2a

--- a/extras/foot/themes/light/2/oasis_mirage_light_2.ini
+++ b/extras/foot/themes/light/2/oasis_mirage_light_2.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_mirage_light_2.ini
-; name: Oasis Mirage Light 2
-; author: uhs-robert
+# extras/foot/oasis_mirage_light_2.ini
+# name: Oasis Mirage Light 2
+# author: uhs-robert
 
 [colors]
-cursor=#ebf9f9 #356962
-foreground=#425858
-background=#ebf9f9
+cursor=ebf9f9 356962
+foreground=425858
+background=ebf9f9
 
-selection-foreground=#425858
-selection-background=#c8eeee
+selection-foreground=425858
+selection-background=c8eeee
 
-search-box-no-match=#0f4c44 #9fe0d7
-search-box-match=#351908 #dd986f
+search-box-no-match=0f4c44 9fe0d7
+search-box-match=351908 dd986f
 
-urls=#2d5a6c
-jump-labels=#351908 #dd986f
+urls=2d5a6c
+jump-labels=351908 dd986f
 
-regular0=#545454
-regular1=#c01313
-regular2=#306b4c
-regular3=#686123
-regular4=#1561ae
-regular5=#7f2fdd
-regular6=#366963
-regular7=#57544b
+regular0=545454
+regular1=c01313
+regular2=306b4c
+regular3=686123
+regular4=1561ae
+regular5=7f2fdd
+regular6=366963
+regular7=57544b
 
-bright0=#5e5249
-bright1=#c01313
-bright2=#366d27
-bright3=#8e5115
-bright4=#256782
-bright5=#7e30dd
-bright6=#356961
-bright7=#7b480c
-16=#78491c
-17=#b7282c
+bright0=5e5249
+bright1=c01313
+bright2=366d27
+bright3=8e5115
+bright4=256782
+bright5=7e30dd
+bright6=356961
+bright7=7b480c
+16=78491c
+17=b7282c

--- a/extras/foot/themes/light/2/oasis_night_light_2.ini
+++ b/extras/foot/themes/light/2/oasis_night_light_2.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_night_light_2.ini
-; name: Oasis Night Light 2
-; author: uhs-robert
+# extras/foot/oasis_night_light_2.ini
+# name: Oasis Night Light 2
+# author: uhs-robert
 
 [colors]
-cursor=#e9deb9 #7e430e
-foreground=#54432d
-background=#e9deb9
+cursor=e9deb9 7e430e
+foreground=54432d
+background=e9deb9
 
-selection-foreground=#54432d
-selection-background=#decd96
+selection-foreground=54432d
+selection-background=decd96
 
-search-box-no-match=#4e260e #e1b69d
-search-box-match=#350808 #dd6f6f
+search-box-no-match=4e260e e1b69d
+search-box-match=350808 dd6f6f
 
-urls=#254b5a
-jump-labels=#350808 #dd6f6f
+urls=254b5a
+jump-labels=350808 dd6f6f
 
-regular0=#653d15
-regular1=#a51111
-regular2=#295c41
-regular3=#59531e
-regular4=#125395
-regular5=#6d21c7
-regular6=#2e5954
-regular7=#48463f
+regular0=653d15
+regular1=a51111
+regular2=295c41
+regular3=59531e
+regular4=125395
+regular5=6d21c7
+regular6=2e5954
+regular7=48463f
 
-bright0=#584131
-bright1=#a51111
-bright2=#2e5c22
-bright3=#794512
-bright4=#20586f
-bright5=#6c21c8
-bright6=#2e5a53
-bright7=#673c0a
-16=#643d18
-17=#9f1f24
+bright0=584131
+bright1=a51111
+bright2=2e5c22
+bright3=794512
+bright4=20586f
+bright5=6c21c8
+bright6=2e5a53
+bright7=673c0a
+16=643d18
+17=9f1f24

--- a/extras/foot/themes/light/2/oasis_rose_light_2.ini
+++ b/extras/foot/themes/light/2/oasis_rose_light_2.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_rose_light_2.ini
-; name: Oasis Rose Light 2
-; author: uhs-robert
+# extras/foot/oasis_rose_light_2.ini
+# name: Oasis Rose Light 2
+# author: uhs-robert
 
 [colors]
-cursor=#f9ecf5 #b8141b
-foreground=#61495c
-background=#f9ecf5
+cursor=f9ecf5 b8141b
+foreground=61495c
+background=f9ecf5
 
-selection-foreground=#61495c
-selection-background=#eec9e3
+selection-foreground=61495c
+selection-background=eec9e3
 
-search-box-no-match=#481335 #dba3c6
-search-box-match=#09342f #72dacc
+search-box-no-match=481335 dba3c6
+search-box-match=09342f 72dacc
 
-urls=#2b5667
-jump-labels=#09342f #72dacc
+urls=2b5667
+jump-labels=09342f 72dacc
 
-regular0=#505050
-regular1=#b91313
-regular2=#2e6749
-regular3=#645e22
-regular4=#145da7
-regular5=#7a28db
-regular6=#34655f
-regular7=#535048
+regular0=505050
+regular1=b91313
+regular2=2e6749
+regular3=645e22
+regular4=145da7
+regular5=7a28db
+regular6=34655f
+regular7=535048
 
-bright0=#5a4e46
-bright1=#b91313
-bright2=#346826
-bright3=#884e14
-bright4=#24637d
-bright5=#7929dc
-bright6=#33655e
-bright7=#76450c
-16=#73461b
-17=#645d2a
+bright0=5a4e46
+bright1=b91313
+bright2=346826
+bright3=884e14
+bright4=24637d
+bright5=7929dc
+bright6=33655e
+bright7=76450c
+16=73461b
+17=645d2a

--- a/extras/foot/themes/light/2/oasis_sol_light_2.ini
+++ b/extras/foot/themes/light/2/oasis_sol_light_2.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_sol_light_2.ini
-; name: Oasis Sol Light 2
-; author: uhs-robert
+# extras/foot/oasis_sol_light_2.ini
+# name: Oasis Sol Light 2
+# author: uhs-robert
 
 [colors]
-cursor=#f8eae7 #ad262a
-foreground=#793e33
-background=#f8eae7
+cursor=f8eae7 ad262a
+foreground=793e33
+background=f8eae7
 
-selection-foreground=#793e33
-selection-background=#eecbc3
+selection-foreground=793e33
+selection-background=eecbc3
 
-search-box-no-match=#4e0e0e #e19d9d
-search-box-match=#0d311f #7ad1a7
+search-box-no-match=4e0e0e e19d9d
+search-box-match=0d311f 7ad1a7
 
-urls=#2a5465
-jump-labels=#0d311f #7ad1a7
+urls=2a5465
+jump-labels=0d311f 7ad1a7
 
-regular0=#4f4f4f
-regular1=#b61212
-regular2=#2d6548
-regular3=#635c21
-regular4=#145ca4
-regular5=#7925db
-regular6=#33635d
-regular7=#524f47
+regular0=4f4f4f
+regular1=b61212
+regular2=2d6548
+regular3=635c21
+regular4=145ca4
+regular5=7925db
+regular6=33635d
+regular7=524f47
 
-bright0=#594d45
-bright1=#b61212
-bright2=#336625
-bright3=#864d14
-bright4=#23627b
-bright5=#7826db
-bright6=#33635c
-bright7=#74430b
-16=#71451b
-17=#635c29
+bright0=594d45
+bright1=b61212
+bright2=336625
+bright3=864d14
+bright4=23627b
+bright5=7826db
+bright6=33635c
+bright7=74430b
+16=71451b
+17=635c29

--- a/extras/foot/themes/light/2/oasis_starlight_light_2.ini
+++ b/extras/foot/themes/light/2/oasis_starlight_light_2.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_starlight_light_2.ini
-; name: Oasis Starlight Light 2
-; author: uhs-robert
+# extras/foot/oasis_starlight_light_2.ini
+# name: Oasis Starlight Light 2
+# author: uhs-robert
 
 [colors]
-cursor=#f9f5ec #1462a7
-foreground=#5b5341
-background=#f9f5ec
+cursor=f9f5ec 1462a7
+foreground=5b5341
+background=f9f5ec
 
-selection-foreground=#5b5341
-selection-background=#eee3c9
+selection-foreground=5b5341
+selection-background=eee3c9
 
-search-box-no-match=#473c15 #dacfa4
-search-box-match=#351908 #dd986f
+search-box-no-match=473c15 dacfa4
+search-box-match=351908 dd986f
 
-urls=#2d596b
-jump-labels=#351908 #dd986f
+urls=2d596b
+jump-labels=351908 dd986f
 
-regular0=#545454
-regular1=#bf1313
-regular2=#306b4b
-regular3=#686123
-regular4=#1561ad
-regular5=#7f2edd
-regular6=#366862
-regular7=#56544b
+regular0=545454
+regular1=bf1313
+regular2=306b4b
+regular3=686123
+regular4=1561ad
+regular5=7f2edd
+regular6=366862
+regular7=56544b
 
-bright0=#5e5149
-bright1=#bf1313
-bright2=#366c27
-bright3=#8d5115
-bright4=#256781
-bright5=#7d2fdd
-bright6=#356961
-bright7=#7a470c
-16=#77491c
-17=#be151c
+bright0=5e5149
+bright1=bf1313
+bright2=366c27
+bright3=8d5115
+bright4=256781
+bright5=7d2fdd
+bright6=356961
+bright7=7a470c
+16=77491c
+17=be151c

--- a/extras/foot/themes/light/2/oasis_twilight_light_2.ini
+++ b/extras/foot/themes/light/2/oasis_twilight_light_2.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_twilight_light_2.ini
-; name: Oasis Twilight Light 2
-; author: uhs-robert
+# extras/foot/oasis_twilight_light_2.ini
+# name: Oasis Twilight Light 2
+# author: uhs-robert
 
 [colors]
-cursor=#efecf9 #7f18e1
-foreground=#544975
-background=#efecf9
+cursor=efecf9 7f18e1
+foreground=544975
+background=efecf9
 
-selection-foreground=#544975
-selection-background=#d2c9ee
+selection-foreground=544975
+selection-background=d2c9ee
 
-search-box-no-match=#31124a #c3a1dd
-search-box-match=#31290d #d1be7a
+search-box-no-match=31124a c3a1dd
+search-box-match=31290d d1be7a
 
-urls=#2a5566
-jump-labels=#31290d #d1be7a
+urls=2a5566
+jump-labels=31290d d1be7a
 
-regular0=#4f4f4f
-regular1=#b71212
-regular2=#2e6648
-regular3=#635d21
-regular4=#145ca5
-regular5=#7925db
-regular6=#33645e
-regular7=#524f47
+regular0=4f4f4f
+regular1=b71212
+regular2=2e6648
+regular3=635d21
+regular4=145ca5
+regular5=7925db
+regular6=33645e
+regular7=524f47
 
-bright0=#594d45
-bright1=#b71212
-bright2=#346725
-bright3=#874d14
-bright4=#23627b
-bright5=#7827db
-bright6=#33645c
-bright7=#75440b
-16=#71451b
-17=#b02328
+bright0=594d45
+bright1=b71212
+bright2=346725
+bright3=874d14
+bright4=23627b
+bright5=7827db
+bright6=33645c
+bright7=75440b
+16=71451b
+17=b02328

--- a/extras/foot/themes/light/3/oasis_abyss_light_3.ini
+++ b/extras/foot/themes/light/3/oasis_abyss_light_3.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_abyss_light_3.ini
-; name: Oasis Abyss Light 3
-; author: uhs-robert
+# extras/foot/oasis_abyss_light_3.ini
+# name: Oasis Abyss Light 3
+# author: uhs-robert
 
 [colors]
-cursor=#f7e5d4 #ab1e22
-foreground=#524b43
-background=#f7e5d4
+cursor=f7e5d4 ab1e22
+foreground=524b43
+background=f7e5d4
 
-selection-foreground=#524b43
-selection-background=#f0cead
+selection-foreground=524b43
+selection-background=f0cead
 
-search-box-no-match=#4e0e0e #e19d9d
-search-box-match=#0d311d #7ad1a1
+search-box-no-match=4e0e0e e19d9d
+search-box-match=0d311d 7ad1a1
 
-urls=#285162
-jump-labels=#0d311d #7ad1a1
+urls=285162
+jump-labels=0d311d 7ad1a1
 
-regular0=#4c4c4c
-regular1=#b01212
-regular2=#2c6245
-regular3=#605920
-regular4=#13599e
-regular5=#7523d5
-regular6=#31605b
-regular7=#4f4c44
+regular0=4c4c4c
+regular1=b01212
+regular2=2c6245
+regular3=605920
+regular4=13599e
+regular5=7523d5
+regular6=31605b
+regular7=4f4c44
 
-bright0=#554a42
-bright1=#b01212
-bright2=#326324
-bright3=#824a14
-bright4=#225f77
-bright5=#7423d6
-bright6=#316059
-bright7=#70410b
-16=#6d421a
-17=#605928
+bright0=554a42
+bright1=b01212
+bright2=326324
+bright3=824a14
+bright4=225f77
+bright5=7423d6
+bright6=316059
+bright7=70410b
+16=6d421a
+17=605928

--- a/extras/foot/themes/light/3/oasis_cactus_light_3.ini
+++ b/extras/foot/themes/light/3/oasis_cactus_light_3.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_cactus_light_3.ini
-; name: Oasis Cactus Light 3
-; author: uhs-robert
+# extras/foot/oasis_cactus_light_3.ini
+# name: Oasis Cactus Light 3
+# author: uhs-robert
 
 [colors]
-cursor=#e0f0e7 #3a643d
-foreground=#405348
-background=#e0f0e7
+cursor=e0f0e7 3a643d
+foreground=405348
+background=e0f0e7
 
-selection-foreground=#405348
-selection-background=#c1e1cf
+selection-foreground=405348
+selection-background=c1e1cf
 
-search-box-no-match=#15472f #a4dac0
-search-box-match=#350808 #dd6f6f
+search-box-no-match=15472f a4dac0
+search-box-match=350808 dd6f6f
 
-urls=#2a5465
-jump-labels=#350808 #dd6f6f
+urls=2a5465
+jump-labels=350808 dd6f6f
 
-regular0=#4e4e4e
-regular1=#b51212
-regular2=#2d6547
-regular3=#625c21
-regular4=#145ca2
-regular5=#7823db
-regular6=#32635d
-regular7=#514e47
+regular0=4e4e4e
+regular1=b51212
+regular2=2d6547
+regular3=625c21
+regular4=145ca2
+regular5=7823db
+regular6=32635d
+regular7=514e47
 
-bright0=#574c44
-bright1=#b51212
-bright2=#336625
-bright3=#864d14
-bright4=#23617a
-bright5=#7725db
-bright6=#32635c
-bright7=#73430b
-16=#70441b
-17=#ac2529
+bright0=574c44
+bright1=b51212
+bright2=336625
+bright3=864d14
+bright4=23617a
+bright5=7725db
+bright6=32635c
+bright7=73430b
+16=70441b
+17=ac2529

--- a/extras/foot/themes/light/3/oasis_canyon_light_3.ini
+++ b/extras/foot/themes/light/3/oasis_canyon_light_3.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_canyon_light_3.ini
-; name: Oasis Canyon Light 3
-; author: uhs-robert
+# extras/foot/oasis_canyon_light_3.ini
+# name: Oasis Canyon Light 3
+# author: uhs-robert
 
 [colors]
-cursor=#f7e7d4 #89480f
-foreground=#5d4a33
-background=#f7e7d4
+cursor=f7e7d4 89480f
+foreground=5d4a33
+background=f7e7d4
 
-selection-foreground=#5d4a33
-selection-background=#f0d1ad
+selection-foreground=5d4a33
+selection-background=f0d1ad
 
-search-box-no-match=#4e260e #e1b69d
-search-box-match=#092234 #72aeda
+search-box-no-match=4e260e e1b69d
+search-box-match=092234 72aeda
 
-urls=#295263
-jump-labels=#092234 #72aeda
+urls=295263
+jump-labels=092234 72aeda
 
-regular0=#4d4d4d
-regular1=#b21212
-regular2=#2c6346
-regular3=#615a20
-regular4=#135a9f
-regular5=#7623d7
-regular6=#31615b
-regular7=#504d45
+regular0=4d4d4d
+regular1=b21212
+regular2=2c6346
+regular3=615a20
+regular4=135a9f
+regular5=7623d7
+regular6=31615b
+regular7=504d45
 
-bright0=#564b43
-bright1=#b21212
-bright2=#326424
-bright3=#834b14
-bright4=#225f77
-bright5=#7523d8
-bright6=#31615a
-bright7=#71420b
-16=#6e431b
-17=#ab2126
+bright0=564b43
+bright1=b21212
+bright2=326424
+bright3=834b14
+bright4=225f77
+bright5=7523d8
+bright6=31615a
+bright7=71420b
+16=6e431b
+17=ab2126

--- a/extras/foot/themes/light/3/oasis_desert_light_3.ini
+++ b/extras/foot/themes/light/3/oasis_desert_light_3.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_desert_light_3.ini
-; name: Oasis Desert Light 3
-; author: uhs-robert
+# extras/foot/oasis_desert_light_3.ini
+# name: Oasis Desert Light 3
+# author: uhs-robert
 
 [colors]
-cursor=#f7e7d4 #645918
-foreground=#5a4a38
-background=#f7e7d4
+cursor=f7e7d4 645918
+foreground=5a4a38
+background=f7e7d4
 
-selection-foreground=#5a4a38
-selection-background=#f0d1ad
+selection-foreground=5a4a38
+selection-background=f0d1ad
 
-search-box-no-match=#473c15 #dacfa4
-search-box-match=#351908 #dd986f
+search-box-no-match=473c15 dacfa4
+search-box-match=351908 dd986f
 
-urls=#295263
-jump-labels=#351908 #dd986f
+urls=295263
+jump-labels=351908 dd986f
 
-regular0=#4d4d4d
-regular1=#b21212
-regular2=#2c6346
-regular3=#615a20
-regular4=#135a9f
-regular5=#7623d7
-regular6=#31615b
-regular7=#504d45
+regular0=4d4d4d
+regular1=b21212
+regular2=2c6346
+regular3=615a20
+regular4=135a9f
+regular5=7623d7
+regular6=31615b
+regular7=504d45
 
-bright0=#564b43
-bright1=#b21212
-bright2=#326424
-bright3=#834b14
-bright4=#225f77
-bright5=#7523d8
-bright6=#31615a
-bright7=#71420b
-16=#6e431b
-17=#ab2126
+bright0=564b43
+bright1=b21212
+bright2=326424
+bright3=834b14
+bright4=225f77
+bright5=7523d8
+bright6=31615a
+bright7=71420b
+16=6e431b
+17=ab2126

--- a/extras/foot/themes/light/3/oasis_dune_light_3.ini
+++ b/extras/foot/themes/light/3/oasis_dune_light_3.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_dune_light_3.ini
-; name: Oasis Dune Light 3
-; author: uhs-robert
+# extras/foot/oasis_dune_light_3.ini
+# name: Oasis Dune Light 3
+# author: uhs-robert
 
 [colors]
-cursor=#f4efdd #685c19
-foreground=#525047
-background=#f4efdd
+cursor=f4efdd 685c19
+foreground=525047
+background=f4efdd
 
-selection-foreground=#525047
-selection-background=#e9dfba
+selection-foreground=525047
+selection-background=e9dfba
 
-search-box-no-match=#473c15 #dacfa4
-search-box-match=#210b32 #ab76d6
+search-box-no-match=473c15 dacfa4
+search-box-match=210b32 ab76d6
 
-urls=#2b5567
-jump-labels=#210b32 #ab76d6
+urls=2b5567
+jump-labels=210b32 ab76d6
 
-regular0=#505050
-regular1=#b81313
-regular2=#2e6749
-regular3=#645d21
-regular4=#145da5
-regular5=#7a26dc
-regular6=#33645f
-regular7=#535048
+regular0=505050
+regular1=b81313
+regular2=2e6749
+regular3=645d21
+regular4=145da5
+regular5=7a26dc
+regular6=33645f
+regular7=535048
 
-bright0=#594e45
-bright1=#b81313
-bright2=#346826
-bright3=#884e14
-bright4=#23637c
-bright5=#7928dc
-bright6=#33645d
-bright7=#76440b
-16=#73461c
-17=#ad2a2e
+bright0=594e45
+bright1=b81313
+bright2=346826
+bright3=884e14
+bright4=23637c
+bright5=7928dc
+bright6=33645d
+bright7=76440b
+16=73461c
+17=ad2a2e

--- a/extras/foot/themes/light/3/oasis_lagoon_light_3.ini
+++ b/extras/foot/themes/light/3/oasis_lagoon_light_3.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_lagoon_light_3.ini
-; name: Oasis Lagoon Light 3
-; author: uhs-robert
+# extras/foot/oasis_lagoon_light_3.ini
+# name: Oasis Lagoon Light 3
+# author: uhs-robert
 
 [colors]
-cursor=#d9e5f7 #125895
-foreground=#384b68
-background=#d9e5f7
+cursor=d9e5f7 125895
+foreground=384b68
+background=d9e5f7
 
-selection-foreground=#384b68
-selection-background=#b3cbef
+selection-foreground=384b68
+selection-background=b3cbef
 
-search-box-no-match=#0f384c #9fcae0
-search-box-match=#351908 #dd986f
+search-box-no-match=0f384c 9fcae0
+search-box-match=351908 dd986f
 
-urls=#274f5f
-jump-labels=#351908 #dd986f
+urls=274f5f
+jump-labels=351908 dd986f
 
-regular0=#4a4a4a
-regular1=#ac1111
-regular2=#2b6044
-regular3=#5d571f
-regular4=#13579a
-regular5=#7222cf
-regular6=#305d58
-regular7=#4d4a42
+regular0=4a4a4a
+regular1=ac1111
+regular2=2b6044
+regular3=5d571f
+regular4=13579a
+regular5=7222cf
+regular6=305d58
+regular7=4d4a42
 
-bright0=#524840
-bright1=#ac1111
-bright2=#306023
-bright3=#7e4813
-bright4=#215c74
-bright5=#7122d1
-bright6=#2f5d57
-bright7=#6c3f0b
-16=#69401a
-17=#a71e21
+bright0=524840
+bright1=ac1111
+bright2=306023
+bright3=7e4813
+bright4=215c74
+bright5=7122d1
+bright6=2f5d57
+bright7=6c3f0b
+16=69401a
+17=a71e21

--- a/extras/foot/themes/light/3/oasis_midnight_light_3.ini
+++ b/extras/foot/themes/light/3/oasis_midnight_light_3.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_midnight_light_3.ini
-; name: Oasis Midnight Light 3
-; author: uhs-robert
+# extras/foot/oasis_midnight_light_3.ini
+# name: Oasis Midnight Light 3
+# author: uhs-robert
 
 [colors]
-cursor=#f7e2d4 #a82025
-foreground=#524943
-background=#f7e2d4
+cursor=f7e2d4 a82025
+foreground=524943
+background=f7e2d4
 
-selection-foreground=#524943
-selection-background=#f0c8ad
+selection-foreground=524943
+selection-background=f0c8ad
 
-search-box-no-match=#4e0e0e #e19d9d
-search-box-match=#0d311d #7ad1a1
+search-box-no-match=4e0e0e e19d9d
+search-box-match=0d311d 7ad1a1
 
-urls=#285060
-jump-labels=#0d311d #7ad1a1
+urls=285060
+jump-labels=0d311d 7ad1a1
 
-regular0=#4b4b4b
-regular1=#ae1212
-regular2=#2b6144
-regular3=#5e581f
-regular4=#13589c
-regular5=#7322d2
-regular6=#305e59
-regular7=#4e4b43
+regular0=4b4b4b
+regular1=ae1212
+regular2=2b6144
+regular3=5e581f
+regular4=13589c
+regular5=7322d2
+regular6=305e59
+regular7=4e4b43
 
-bright0=#534941
-bright1=#ae1212
-bright2=#316223
-bright3=#804913
-bright4=#215d75
-bright5=#7223d3
-bright6=#305f58
-bright7=#6e400b
-16=#6b411a
-17=#5e5727
+bright0=534941
+bright1=ae1212
+bright2=316223
+bright3=804913
+bright4=215d75
+bright5=7223d3
+bright6=305f58
+bright7=6e400b
+16=6b411a
+17=5e5727

--- a/extras/foot/themes/light/3/oasis_mirage_light_3.ini
+++ b/extras/foot/themes/light/3/oasis_mirage_light_3.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_mirage_light_3.ini
-; name: Oasis Mirage Light 3
-; author: uhs-robert
+# extras/foot/oasis_mirage_light_3.ini
+# name: Oasis Mirage Light 3
+# author: uhs-robert
 
 [colors]
-cursor=#dbf5f5 #32655d
-foreground=#405454
-background=#dbf5f5
+cursor=dbf5f5 32655d
+foreground=405454
+background=dbf5f5
 
-selection-foreground=#405454
-selection-background=#b7ebeb
+selection-foreground=405454
+selection-background=b7ebeb
 
-search-box-no-match=#0f4c44 #9fe0d7
-search-box-match=#351908 #dd986f
+search-box-no-match=0f4c44 9fe0d7
+search-box-match=351908 dd986f
 
-urls=#2b5667
-jump-labels=#351908 #dd986f
+urls=2b5667
+jump-labels=351908 dd986f
 
-regular0=#505050
-regular1=#b91313
-regular2=#2e6749
-regular3=#655e21
-regular4=#145ea6
-regular5=#7b27dc
-regular6=#33655f
-regular7=#535048
+regular0=505050
+regular1=b91313
+regular2=2e6749
+regular3=655e21
+regular4=145ea6
+regular5=7b27dc
+regular6=33655f
+regular7=535048
 
-bright0=#5a4e46
-bright1=#b91313
-bright2=#346926
-bright3=#894e15
-bright4=#24647d
-bright5=#7929dc
-bright6=#33655e
-bright7=#76450c
-16=#73461c
-17=#b0262a
+bright0=5a4e46
+bright1=b91313
+bright2=346926
+bright3=894e15
+bright4=24647d
+bright5=7929dc
+bright6=33655e
+bright7=76450c
+16=73461c
+17=b0262a

--- a/extras/foot/themes/light/3/oasis_night_light_3.ini
+++ b/extras/foot/themes/light/3/oasis_night_light_3.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_night_light_3.ini
-; name: Oasis Night Light 3
-; author: uhs-robert
+# extras/foot/oasis_night_light_3.ini
+# name: Oasis Night Light 3
+# author: uhs-robert
 
 [colors]
-cursor=#e6dbb2 #7c410d
-foreground=#52412d
-background=#e6dbb2
+cursor=e6dbb2 7c410d
+foreground=52412d
+background=e6dbb2
 
-selection-foreground=#52412d
-selection-background=#dbca8f
+selection-foreground=52412d
+selection-background=dbca8f
 
-search-box-no-match=#4e260e #e1b69d
-search-box-match=#350808 #dd6f6f
+search-box-no-match=4e260e e1b69d
+search-box-match=350808 dd6f6f
 
-urls=#244958
-jump-labels=#350808 #dd6f6f
+urls=244958
+jump-labels=350808 dd6f6f
 
-regular0=#623b14
-regular1=#a11010
-regular2=#285a3f
-regular3=#57511d
-regular4=#125190
-regular5=#6b20c3
-regular6=#2d5753
-regular7=#47443d
+regular0=623b14
+regular1=a11010
+regular2=285a3f
+regular3=57511d
+regular4=125190
+regular5=6b20c3
+regular6=2d5753
+regular7=47443d
 
-bright0=#573f30
-bright1=#a11010
-bright2=#2d5a21
-bright3=#774412
-bright4=#1f566c
-bright5=#6a20c4
-bright6=#2c5851
-bright7=#643a0a
-16=#623b18
-17=#9b1e23
+bright0=573f30
+bright1=a11010
+bright2=2d5a21
+bright3=774412
+bright4=1f566c
+bright5=6a20c4
+bright6=2c5851
+bright7=643a0a
+16=623b18
+17=9b1e23

--- a/extras/foot/themes/light/3/oasis_rose_light_3.ini
+++ b/extras/foot/themes/light/3/oasis_rose_light_3.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_rose_light_3.ini
-; name: Oasis Rose Light 3
-; author: uhs-robert
+# extras/foot/oasis_rose_light_3.ini
+# name: Oasis Rose Light 3
+# author: uhs-robert
 
 [colors]
-cursor=#f4ddee #ab1318
-foreground=#594353
-background=#f4ddee
+cursor=f4ddee ab1318
+foreground=594353
+background=f4ddee
 
-selection-foreground=#594353
-selection-background=#e9badd
+selection-foreground=594353
+selection-background=e9badd
 
-search-box-no-match=#481335 #dba3c6
-search-box-match=#09342f #72dacc
+search-box-no-match=481335 dba3c6
+search-box-match=09342f 72dacc
 
-urls=#274e5e
-jump-labels=#09342f #72dacc
+urls=274e5e
+jump-labels=09342f 72dacc
 
-regular0=#494949
-regular1=#ab1111
-regular2=#2b5f43
-regular3=#5d561f
-regular4=#135699
-regular5=#7222cf
-regular6=#2f5d58
-regular7=#4c4942
+regular0=494949
+regular1=ab1111
+regular2=2b5f43
+regular3=5d561f
+regular4=135699
+regular5=7222cf
+regular6=2f5d58
+regular7=4c4942
 
-bright0=#524840
-bright1=#ab1111
-bright2=#306023
-bright3=#7e4813
-bright4=#215c73
-bright5=#7022d0
-bright6=#2f5d57
-bright7=#6c3f0b
-16=#69401a
-17=#5d5626
+bright0=524840
+bright1=ab1111
+bright2=306023
+bright3=7e4813
+bright4=215c73
+bright5=7022d0
+bright6=2f5d57
+bright7=6c3f0b
+16=69401a
+17=5d5626

--- a/extras/foot/themes/light/3/oasis_sol_light_3.ini
+++ b/extras/foot/themes/light/3/oasis_sol_light_3.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_sol_light_3.ini
-; name: Oasis Sol Light 3
-; author: uhs-robert
+# extras/foot/oasis_sol_light_3.ini
+# name: Oasis Sol Light 3
+# author: uhs-robert
 
 [colors]
-cursor=#f7d9d4 #9f2326
-foreground=#6d382e
-background=#f7d9d4
+cursor=f7d9d4 9f2326
+foreground=6d382e
+background=f7d9d4
 
-selection-foreground=#6d382e
-selection-background=#f0b7ad
+selection-foreground=6d382e
+selection-background=f0b7ad
 
-search-box-no-match=#4e0e0e #e19d9d
-search-box-match=#0d311f #7ad1a7
+search-box-no-match=4e0e0e e19d9d
+search-box-match=0d311f 7ad1a7
 
-urls=#264c5b
-jump-labels=#0d311f #7ad1a7
+urls=264c5b
+jump-labels=0d311f 7ad1a7
 
-regular0=#474747
-regular1=#a71111
-regular2=#295d41
-regular3=#5b541e
-regular4=#125495
-regular5=#6f21c9
-regular6=#2e5a55
-regular7=#4a4740
+regular0=474747
+regular1=a71111
+regular2=295d41
+regular3=5b541e
+regular4=125495
+regular5=6f21c9
+regular6=2e5a55
+regular7=4a4740
 
-bright0=#4f453e
-bright1=#a71111
-bright2=#2f5e22
-bright3=#7b4612
-bright4=#205970
-bright5=#6d21ca
-bright6=#2e5b54
-bright7=#683d0a
-16=#663e19
-17=#5b5425
+bright0=4f453e
+bright1=a71111
+bright2=2f5e22
+bright3=7b4612
+bright4=205970
+bright5=6d21ca
+bright6=2e5b54
+bright7=683d0a
+16=663e19
+17=5b5425

--- a/extras/foot/themes/light/3/oasis_starlight_light_3.ini
+++ b/extras/foot/themes/light/3/oasis_starlight_light_3.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_starlight_light_3.ini
-; name: Oasis Starlight Light 3
-; author: uhs-robert
+# extras/foot/oasis_starlight_light_3.ini
+# name: Oasis Starlight Light 3
+# author: uhs-robert
 
 [colors]
-cursor=#f4eddd #135d9e
-foreground=#564f3e
-background=#f4eddd
+cursor=f4eddd 135d9e
+foreground=564f3e
+background=f4eddd
 
-selection-foreground=#564f3e
-selection-background=#e9dbba
+selection-foreground=564f3e
+selection-background=e9dbba
 
-search-box-no-match=#473c15 #dacfa4
-search-box-match=#351908 #dd986f
+search-box-no-match=473c15 dacfa4
+search-box-match=351908 dd986f
 
-urls=#2a5466
-jump-labels=#351908 #dd986f
+urls=2a5466
+jump-labels=351908 dd986f
 
-regular0=#4f4f4f
-regular1=#b71212
-regular2=#2e6648
-regular3=#645d21
-regular4=#145ca4
-regular5=#7924dc
-regular6=#33635e
-regular7=#524f47
+regular0=4f4f4f
+regular1=b71212
+regular2=2e6648
+regular3=645d21
+regular4=145ca4
+regular5=7924dc
+regular6=33635e
+regular7=524f47
 
-bright0=#584d45
-bright1=#b71212
-bright2=#336725
-bright3=#874d14
-bright4=#23627b
-bright5=#7826dc
-bright6=#33645d
-bright7=#74440b
-16=#71451c
-17=#b61419
+bright0=584d45
+bright1=b71212
+bright2=336725
+bright3=874d14
+bright4=23627b
+bright5=7826dc
+bright6=33645d
+bright7=74440b
+16=71451c
+17=b61419

--- a/extras/foot/themes/light/3/oasis_twilight_light_3.ini
+++ b/extras/foot/themes/light/3/oasis_twilight_light_3.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_twilight_light_3.ini
-; name: Oasis Twilight Light 3
-; author: uhs-robert
+# extras/foot/oasis_twilight_light_3.ini
+# name: Oasis Twilight Light 3
+# author: uhs-robert
 
 [colors]
-cursor=#e2ddf4 #7416cd
-foreground=#4a4268
-background=#e2ddf4
+cursor=e2ddf4 7416cd
+foreground=4a4268
+background=e2ddf4
 
-selection-foreground=#4a4268
-selection-background=#c4bae9
+selection-foreground=4a4268
+selection-background=c4bae9
 
-search-box-no-match=#31124a #c3a1dd
-search-box-match=#31290d #d1be7a
+search-box-no-match=31124a c3a1dd
+search-box-match=31290d d1be7a
 
-urls=#264c5c
-jump-labels=#31290d #d1be7a
+urls=264c5c
+jump-labels=31290d d1be7a
 
-regular0=#474747
-regular1=#a71111
-regular2=#2a5d42
-regular3=#5b541e
-regular4=#125496
-regular5=#6f21ca
-regular6=#2e5b56
-regular7=#4a4740
+regular0=474747
+regular1=a71111
+regular2=2a5d42
+regular3=5b541e
+regular4=125496
+regular5=6f21ca
+regular6=2e5b56
+regular7=4a4740
 
-bright0=#4f453e
-bright1=#a71111
-bright2=#2f5e22
-bright3=#7b4612
-bright4=#205970
-bright5=#6d21cb
-bright6=#2e5b54
-bright7=#693d0a
-16=#663e19
-17=#a11f24
+bright0=4f453e
+bright1=a71111
+bright2=2f5e22
+bright3=7b4612
+bright4=205970
+bright5=6d21cb
+bright6=2e5b54
+bright7=693d0a
+16=663e19
+17=a11f24

--- a/extras/foot/themes/light/4/oasis_abyss_light_4.ini
+++ b/extras/foot/themes/light/4/oasis_abyss_light_4.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_abyss_light_4.ini
-; name: Oasis Abyss Light 4
-; author: uhs-robert
+# extras/foot/oasis_abyss_light_4.ini
+# name: Oasis Abyss Light 4
+# author: uhs-robert
 
 [colors]
-cursor=#f5ddc7 #a41c20
-foreground=#4e473f
-background=#f5ddc7
+cursor=f5ddc7 a41c20
+foreground=4e473f
+background=f5ddc7
 
-selection-foreground=#4e473f
-selection-background=#eec5a0
+selection-foreground=4e473f
+selection-background=eec5a0
 
-search-box-no-match=#4e0e0e #e19d9d
-search-box-match=#0d311d #7ad1a1
+search-box-no-match=4e0e0e e19d9d
+search-box-match=0d311d 7ad1a1
 
-urls=#264d5d
-jump-labels=#0d311d #7ad1a1
+urls=264d5d
+jump-labels=0d311d 7ad1a1
 
-regular0=#484848
-regular1=#a91111
-regular2=#2a5e42
-regular3=#5b551f
-regular4=#125597
-regular5=#6f21cb
-regular6=#2f5b56
-regular7=#4a4841
+regular0=484848
+regular1=a91111
+regular2=2a5e42
+regular3=5b551f
+regular4=125597
+regular5=6f21cb
+regular6=2f5b56
+regular7=4a4841
 
-bright0=#50463f
-bright1=#a91010
-bright2=#305e23
-bright3=#7c4712
-bright4=#205a71
-bright5=#6f21cd
-bright6=#2f5c55
-bright7=#693e0b
-16=#673e19
-17=#5b5526
+bright0=50463f
+bright1=a91010
+bright2=305e23
+bright3=7c4712
+bright4=205a71
+bright5=6f21cd
+bright6=2f5c55
+bright7=693e0b
+16=673e19
+17=5b5526

--- a/extras/foot/themes/light/4/oasis_cactus_light_4.ini
+++ b/extras/foot/themes/light/4/oasis_cactus_light_4.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_cactus_light_4.ini
-; name: Oasis Cactus Light 4
-; author: uhs-robert
+# extras/foot/oasis_cactus_light_4.ini
+# name: Oasis Cactus Light 4
+# author: uhs-robert
 
 [colors]
-cursor=#d6f0e1 #3a623c
-foreground=#405147
-background=#d6f0e1
+cursor=d6f0e1 3a623c
+foreground=405147
+background=d6f0e1
 
-selection-foreground=#405147
-selection-background=#b4e4c8
+selection-foreground=405147
+selection-background=b4e4c8
 
-search-box-no-match=#15472f #a4dac0
-search-box-match=#350808 #dd6f6f
+search-box-no-match=15472f a4dac0
+search-box-match=350808 dd6f6f
 
-urls=#295263
-jump-labels=#350808 #dd6f6f
+urls=295263
+jump-labels=350808 dd6f6f
 
-regular0=#4d4d4d
-regular1=#b31212
-regular2=#2c6446
-regular3=#615a20
-regular4=#135aa0
-regular5=#7623d7
-regular6=#32615c
-regular7=#504d45
+regular0=4d4d4d
+regular1=b31212
+regular2=2c6446
+regular3=615a20
+regular4=135aa0
+regular5=7623d7
+regular6=32615c
+regular7=504d45
 
-bright0=#564b43
-bright1=#b31111
-bright2=#326425
-bright3=#844b14
-bright4=#226078
-bright5=#7523d9
-bright6=#32615a
-bright7=#71420b
-16=#6e431b
-17=#aa2429
+bright0=564b43
+bright1=b31111
+bright2=326425
+bright3=844b14
+bright4=226078
+bright5=7523d9
+bright6=32615a
+bright7=71420b
+16=6e431b
+17=aa2429

--- a/extras/foot/themes/light/4/oasis_canyon_light_4.ini
+++ b/extras/foot/themes/light/4/oasis_canyon_light_4.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_canyon_light_4.ini
-; name: Oasis Canyon Light 4
-; author: uhs-robert
+# extras/foot/oasis_canyon_light_4.ini
+# name: Oasis Canyon Light 4
+# author: uhs-robert
 
 [colors]
-cursor=#f5dfc7 #83440e
-foreground=#574630
-background=#f5dfc7
+cursor=f5dfc7 83440e
+foreground=574630
+background=f5dfc7
 
-selection-foreground=#574630
-selection-background=#eec9a0
+selection-foreground=574630
+selection-background=eec9a0
 
-search-box-no-match=#4e260e #e1b69d
-search-box-match=#092234 #72aeda
+search-box-no-match=4e260e e1b69d
+search-box-match=092234 72aeda
 
-urls=#274e5e
-jump-labels=#092234 #72aeda
+urls=274e5e
+jump-labels=092234 72aeda
 
-regular0=#494949
-regular1=#aa1111
-regular2=#2a5f43
-regular3=#5c561f
-regular4=#135698
-regular5=#7122cd
-regular6=#305c57
-regular7=#4b4941
+regular0=494949
+regular1=aa1111
+regular2=2a5f43
+regular3=5c561f
+regular4=135698
+regular5=7122cd
+regular6=305c57
+regular7=4b4941
 
-bright0=#514740
-bright1=#aa1010
-bright2=#306023
-bright3=#7d4813
-bright4=#205b73
-bright5=#7021cf
-bright6=#2f5d56
-bright7=#6b3e0b
-16=#683f19
-17=#a32124
+bright0=514740
+bright1=aa1010
+bright2=306023
+bright3=7d4813
+bright4=205b73
+bright5=7021cf
+bright6=2f5d56
+bright7=6b3e0b
+16=683f19
+17=a32124

--- a/extras/foot/themes/light/4/oasis_desert_light_4.ini
+++ b/extras/foot/themes/light/4/oasis_desert_light_4.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_desert_light_4.ini
-; name: Oasis Desert Light 4
-; author: uhs-robert
+# extras/foot/oasis_desert_light_4.ini
+# name: Oasis Desert Light 4
+# author: uhs-robert
 
 [colors]
-cursor=#f5dfc7 #5e5517
-foreground=#564634
-background=#f5dfc7
+cursor=f5dfc7 5e5517
+foreground=564634
+background=f5dfc7
 
-selection-foreground=#564634
-selection-background=#eec9a0
+selection-foreground=564634
+selection-background=eec9a0
 
-search-box-no-match=#473c15 #dacfa4
-search-box-match=#351908 #dd986f
+search-box-no-match=473c15 dacfa4
+search-box-match=351908 dd986f
 
-urls=#274e5e
-jump-labels=#351908 #dd986f
+urls=274e5e
+jump-labels=351908 dd986f
 
-regular0=#494949
-regular1=#aa1111
-regular2=#2a5f43
-regular3=#5c561f
-regular4=#135698
-regular5=#7122cd
-regular6=#305c57
-regular7=#4b4941
+regular0=494949
+regular1=aa1111
+regular2=2a5f43
+regular3=5c561f
+regular4=135698
+regular5=7122cd
+regular6=305c57
+regular7=4b4941
 
-bright0=#514740
-bright1=#aa1010
-bright2=#306023
-bright3=#7d4813
-bright4=#205b73
-bright5=#7021cf
-bright6=#2f5d56
-bright7=#6b3e0b
-16=#683f19
-17=#a32124
+bright0=514740
+bright1=aa1010
+bright2=306023
+bright3=7d4813
+bright4=205b73
+bright5=7021cf
+bright6=2f5d56
+bright7=6b3e0b
+16=683f19
+17=a32124

--- a/extras/foot/themes/light/4/oasis_dune_light_4.ini
+++ b/extras/foot/themes/light/4/oasis_dune_light_4.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_dune_light_4.ini
-; name: Oasis Dune Light 4
-; author: uhs-robert
+# extras/foot/oasis_dune_light_4.ini
+# name: Oasis Dune Light 4
+# author: uhs-robert
 
 [colors]
-cursor=#f0e9d1 #635918
-foreground=#4f4d44
-background=#f0e9d1
+cursor=f0e9d1 635918
+foreground=4f4d44
+background=f0e9d1
 
-selection-foreground=#4f4d44
-selection-background=#e5d8ae
+selection-foreground=4f4d44
+selection-background=e5d8ae
 
-search-box-no-match=#473c15 #dacfa4
-search-box-match=#210b32 #ab76d6
+search-box-no-match=473c15 dacfa4
+search-box-match=210b32 ab76d6
 
-urls=#295263
-jump-labels=#210b32 #ab76d6
+urls=295263
+jump-labels=210b32 ab76d6
 
-regular0=#4c4c4c
-regular1=#b21212
-regular2=#2c6346
-regular3=#605a20
-regular4=#135a9f
-regular5=#7623d6
-regular6=#32605b
-regular7=#4f4d45
+regular0=4c4c4c
+regular1=b21212
+regular2=2c6346
+regular3=605a20
+regular4=135a9f
+regular5=7623d6
+regular6=32605b
+regular7=4f4d45
 
-bright0=#564b43
-bright1=#b21111
-bright2=#326425
-bright3=#834b13
-bright4=#225f78
-bright5=#7523d8
-bright6=#316159
-bright7=#70420b
-16=#6e431b
-17=#a7292d
+bright0=564b43
+bright1=b21111
+bright2=326425
+bright3=834b13
+bright4=225f78
+bright5=7523d8
+bright6=316159
+bright7=70420b
+16=6e431b
+17=a7292d

--- a/extras/foot/themes/light/4/oasis_lagoon_light_4.ini
+++ b/extras/foot/themes/light/4/oasis_lagoon_light_4.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_lagoon_light_4.ini
-; name: Oasis Lagoon Light 4
-; author: uhs-robert
+# extras/foot/oasis_lagoon_light_4.ini
+# name: Oasis Lagoon Light 4
+# author: uhs-robert
 
 [colors]
-cursor=#c9dcf7 #11528a
-foreground=#334561
-background=#c9dcf7
+cursor=c9dcf7 11528a
+foreground=334561
+background=c9dcf7
 
-selection-foreground=#334561
-selection-background=#a1c2f1
+selection-foreground=334561
+selection-background=a1c2f1
 
-search-box-no-match=#0f384c #9fcae0
-search-box-match=#351908 #dd986f
+search-box-no-match=0f384c 9fcae0
+search-box-match=351908 dd986f
 
-urls=#244857
-jump-labels=#351908 #dd986f
+urls=244857
+jump-labels=351908 dd986f
 
-regular0=#444444
-regular1=#a11010
-regular2=#28593f
-regular3=#57511d
-regular4=#11518f
-regular5=#6a20c1
-regular6=#2d5752
-regular7=#46443d
+regular0=444444
+regular1=a11010
+regular2=28593f
+regular3=57511d
+regular4=11518f
+regular5=6a20c1
+regular6=2d5752
+regular7=46443d
 
-bright0=#4c423b
-bright1=#a11010
-bright2=#2d5a21
-bright3=#764312
-bright4=#1f566c
-bright5=#691fc3
-bright6=#2c5751
-bright7=#643a0a
-16=#613b18
-17=#9c1b1f
+bright0=4c423b
+bright1=a11010
+bright2=2d5a21
+bright3=764312
+bright4=1f566c
+bright5=691fc3
+bright6=2c5751
+bright7=643a0a
+16=613b18
+17=9c1b1f

--- a/extras/foot/themes/light/4/oasis_midnight_light_4.ini
+++ b/extras/foot/themes/light/4/oasis_midnight_light_4.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_midnight_light_4.ini
-; name: Oasis Midnight Light 4
-; author: uhs-robert
+# extras/foot/oasis_midnight_light_4.ini
+# name: Oasis Midnight Light 4
+# author: uhs-robert
 
 [colors]
-cursor=#f5d8c7 #9e2023
-foreground=#4d443e
-background=#f5d8c7
+cursor=f5d8c7 9e2023
+foreground=4d443e
+background=f5d8c7
 
-selection-foreground=#4d443e
-selection-background=#eebda0
+selection-foreground=4d443e
+selection-background=eebda0
 
-search-box-no-match=#4e0e0e #e19d9d
-search-box-match=#0d311d #7ad1a1
+search-box-no-match=4e0e0e e19d9d
+search-box-match=0d311d 7ad1a1
 
-urls=#254a5a
-jump-labels=#0d311d #7ad1a1
+urls=254a5a
+jump-labels=0d311d 7ad1a1
 
-regular0=#464646
-regular1=#a51111
-regular2=#295b40
-regular3=#59531e
-regular4=#125393
-regular5=#6d21c6
-regular6=#2e5954
-regular7=#48463f
+regular0=464646
+regular1=a51111
+regular2=295b40
+regular3=59531e
+regular4=125393
+regular5=6d21c6
+regular6=2e5954
+regular7=48463f
 
-bright0=#4e443d
-bright1=#a51010
-bright2=#2e5c22
-bright3=#794512
-bright4=#1f586f
-bright5=#6c20c8
-bright6=#2e5953
-bright7=#663c0a
-16=#643d18
-17=#595325
+bright0=4e443d
+bright1=a51010
+bright2=2e5c22
+bright3=794512
+bright4=1f586f
+bright5=6c20c8
+bright6=2e5953
+bright7=663c0a
+16=643d18
+17=595325

--- a/extras/foot/themes/light/4/oasis_mirage_light_4.ini
+++ b/extras/foot/themes/light/4/oasis_mirage_light_4.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_mirage_light_4.ini
-; name: Oasis Mirage Light 4
-; author: uhs-robert
+# extras/foot/oasis_mirage_light_4.ini
+# name: Oasis Mirage Light 4
+# author: uhs-robert
 
 [colors]
-cursor=#cdf4f4 #31635c
-foreground=#3e5252
-background=#cdf4f4
+cursor=cdf4f4 31635c
+foreground=3e5252
+background=cdf4f4
 
-selection-foreground=#3e5252
-selection-background=#a7ecec
+selection-foreground=3e5252
+selection-background=a7ecec
 
-search-box-no-match=#0f4c44 #9fe0d7
-search-box-match=#351908 #dd986f
+search-box-no-match=0f4c44 9fe0d7
+search-box-match=351908 dd986f
 
-urls=#2a5465
-jump-labels=#351908 #dd986f
+urls=2a5465
+jump-labels=351908 dd986f
 
-regular0=#4f4f4f
-regular1=#b51212
-regular2=#2d6548
-regular3=#625c21
-regular4=#145ca2
-regular5=#7824db
-regular6=#33635e
-regular7=#514f47
+regular0=4f4f4f
+regular1=b51212
+regular2=2d6548
+regular3=625c21
+regular4=145ca2
+regular5=7824db
+regular6=33635e
+regular7=514f47
 
-bright0=#584d45
-bright1=#b61212
-bright2=#336625
-bright3=#864d14
-bright4=#23617a
-bright5=#7724dc
-bright6=#33635c
-bright7=#73430c
-16=#71441b
-17=#ad2529
+bright0=584d45
+bright1=b61212
+bright2=336625
+bright3=864d14
+bright4=23617a
+bright5=7724dc
+bright6=33635c
+bright7=73430c
+16=71441b
+17=ad2529

--- a/extras/foot/themes/light/4/oasis_night_light_4.ini
+++ b/extras/foot/themes/light/4/oasis_night_light_4.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_night_light_4.ini
-; name: Oasis Night Light 4
-; author: uhs-robert
+# extras/foot/oasis_night_light_4.ini
+# name: Oasis Night Light 4
+# author: uhs-robert
 
 [colors]
-cursor=#e3d7aa #783f0d
-foreground=#4f3f2b
-background=#e3d7aa
+cursor=e3d7aa 783f0d
+foreground=4f3f2b
+background=e3d7aa
 
-selection-foreground=#4f3f2b
-selection-background=#d8c688
+selection-foreground=4f3f2b
+selection-background=d8c688
 
-search-box-no-match=#4e260e #e1b69d
-search-box-match=#350808 #dd6f6f
+search-box-no-match=4e260e e1b69d
+search-box-match=350808 dd6f6f
 
-urls=#234655
-jump-labels=#350808 #dd6f6f
+urls=234655
+jump-labels=350808 dd6f6f
 
-regular0=#5f3913
-regular1=#9d1010
-regular2=#27573d
-regular3=#544f1c
-regular4=#114f8c
-regular5=#681fbd
-regular6=#2c5550
-regular7=#44423b
+regular0=5f3913
+regular1=9d1010
+regular2=27573d
+regular3=544f1c
+regular4=114f8c
+regular5=681fbd
+regular6=2c5550
+regular7=44423b
 
-bright0=#533d2e
-bright1=#9d0f0f
-bright2=#2c5820
-bright3=#734211
-bright4=#1e5369
-bright5=#671fbe
-bright6=#2b554e
-bright7=#60380a
-16=#5e3917
-17=#961e22
+bright0=533d2e
+bright1=9d0f0f
+bright2=2c5820
+bright3=734211
+bright4=1e5369
+bright5=671fbe
+bright6=2b554e
+bright7=60380a
+16=5e3917
+17=961e22

--- a/extras/foot/themes/light/4/oasis_rose_light_4.ini
+++ b/extras/foot/themes/light/4/oasis_rose_light_4.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_rose_light_4.ini
-; name: Oasis Rose Light 4
-; author: uhs-robert
+# extras/foot/oasis_rose_light_4.ini
+# name: Oasis Rose Light 4
+# author: uhs-robert
 
 [colors]
-cursor=#f3ceea #9f1116
-foreground=#513d4b
-background=#f3ceea
+cursor=f3ceea 9f1116
+foreground=513d4b
+background=f3ceea
 
-selection-foreground=#513d4b
-selection-background=#eaa9da
+selection-foreground=513d4b
+selection-background=eaa9da
 
-search-box-no-match=#481335 #dba3c6
-search-box-match=#09342f #72dacc
+search-box-no-match=481335 dba3c6
+search-box-match=09342f 72dacc
 
-urls=#244756
-jump-labels=#09342f #72dacc
+urls=244756
+jump-labels=09342f 72dacc
 
-regular0=#434343
-regular1=#9f1010
-regular2=#27583e
-regular3=#56501d
-regular4=#11508e
-regular5=#6920bf
-regular6=#2d5651
-regular7=#45433c
+regular0=434343
+regular1=9f1010
+regular2=27583e
+regular3=56501d
+regular4=11508e
+regular5=6920bf
+regular6=2d5651
+regular7=45433c
 
-bright0=#4b413a
-bright1=#9f0f0f
-bright2=#2d5921
-bright3=#754311
-bright4=#1e556a
-bright5=#681fc1
-bright6=#2c5650
-bright7=#62390a
-16=#603a17
-17=#554f24
+bright0=4b413a
+bright1=9f0f0f
+bright2=2d5921
+bright3=754311
+bright4=1e556a
+bright5=681fc1
+bright6=2c5650
+bright7=62390a
+16=603a17
+17=554f24

--- a/extras/foot/themes/light/4/oasis_sol_light_4.ini
+++ b/extras/foot/themes/light/4/oasis_sol_light_4.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_sol_light_4.ini
-; name: Oasis Sol Light 4
-; author: uhs-robert
+# extras/foot/oasis_sol_light_4.ini
+# name: Oasis Sol Light 4
+# author: uhs-robert
 
 [colors]
-cursor=#f5cdc7 #942023
-foreground=#64332a
-background=#f5cdc7
+cursor=f5cdc7 942023
+foreground=64332a
+background=f5cdc7
 
-selection-foreground=#64332a
-selection-background=#eeaaa0
+selection-foreground=64332a
+selection-background=eeaaa0
 
-search-box-no-match=#4e0e0e #e19d9d
-search-box-match=#0d311f #7ad1a7
+search-box-no-match=4e0e0e e19d9d
+search-box-match=0d311f 7ad1a7
 
-urls=#234554
-jump-labels=#0d311f #7ad1a7
+urls=234554
+jump-labels=0d311f 7ad1a7
 
-regular0=#414141
-regular1=#9c1010
-regular2=#26563d
-regular3=#544e1c
-regular4=#114e8b
-regular5=#671fbb
-regular6=#2b5450
-regular7=#43413a
+regular0=414141
+regular1=9c1010
+regular2=26563d
+regular3=544e1c
+regular4=114e8b
+regular5=671fbb
+regular6=2b5450
+regular7=43413a
 
-bright0=#493f39
-bright1=#9c0f0f
-bright2=#2c5720
-bright3=#724111
-bright4=#1e5368
-bright5=#661ebd
-bright6=#2b544e
-bright7=#5f380a
-16=#5d3917
-17=#544e23
+bright0=493f39
+bright1=9c0f0f
+bright2=2c5720
+bright3=724111
+bright4=1e5368
+bright5=661ebd
+bright6=2b544e
+bright7=5f380a
+16=5d3917
+17=544e23

--- a/extras/foot/themes/light/4/oasis_starlight_light_4.ini
+++ b/extras/foot/themes/light/4/oasis_starlight_light_4.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_starlight_light_4.ini
-; name: Oasis Starlight Light 4
-; author: uhs-robert
+# extras/foot/oasis_starlight_light_4.ini
+# name: Oasis Starlight Light 4
+# author: uhs-robert
 
 [colors]
-cursor=#f0e6d1 #125a97
-foreground=#524b3b
-background=#f0e6d1
+cursor=f0e6d1 125a97
+foreground=524b3b
+background=f0e6d1
 
-selection-foreground=#524b3b
-selection-background=#e5d3ae
+selection-foreground=524b3b
+selection-background=e5d3ae
 
-search-box-no-match=#473c15 #dacfa4
-search-box-match=#351908 #dd986f
+search-box-no-match=473c15 dacfa4
+search-box-match=351908 dd986f
 
-urls=#285061
-jump-labels=#351908 #dd986f
+urls=285061
+jump-labels=351908 dd986f
 
-regular0=#4b4b4b
-regular1=#af1212
-regular2=#2b6245
-regular3=#5f5820
-regular4=#13589d
-regular5=#7423d3
-regular6=#315f5a
-regular7=#4e4b44
+regular0=4b4b4b
+regular1=af1212
+regular2=2b6245
+regular3=5f5820
+regular4=13589d
+regular5=7423d3
+regular6=315f5a
+regular7=4e4b44
 
-bright0=#544942
-bright1=#af1111
-bright2=#326224
-bright3=#814a13
-bright4=#215e76
-bright5=#7322d5
-bright6=#315f58
-bright7=#6e400b
-16=#6c411a
-17=#af1319
+bright0=544942
+bright1=af1111
+bright2=326224
+bright3=814a13
+bright4=215e76
+bright5=7322d5
+bright6=315f58
+bright7=6e400b
+16=6c411a
+17=af1319

--- a/extras/foot/themes/light/4/oasis_twilight_light_4.ini
+++ b/extras/foot/themes/light/4/oasis_twilight_light_4.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_twilight_light_4.ini
-; name: Oasis Twilight Light 4
-; author: uhs-robert
+# extras/foot/oasis_twilight_light_4.ini
+# name: Oasis Twilight Light 4
+# author: uhs-robert
 
 [colors]
-cursor=#d7cef3 #6914ba
-foreground=#433a5c
-background=#d7cef3
+cursor=d7cef3 6914ba
+foreground=433a5c
+background=d7cef3
 
-selection-foreground=#433a5c
-selection-background=#b9a9ea
+selection-foreground=433a5c
+selection-background=b9a9ea
 
-search-box-no-match=#31124a #c3a1dd
-search-box-match=#31290d #d1be7a
+search-box-no-match=31124a c3a1dd
+search-box-match=31290d d1be7a
 
-urls=#224351
-jump-labels=#31290d #d1be7a
+urls=224351
+jump-labels=31290d d1be7a
 
-regular0=#3f3f3f
-regular1=#980f0f
-regular2=#25543b
-regular3=#524c1b
-regular4=#104c87
-regular5=#641eb7
-regular6=#2a524e
-regular7=#413f39
+regular0=3f3f3f
+regular1=980f0f
+regular2=25543b
+regular3=524c1b
+regular4=104c87
+regular5=641eb7
+regular6=2a524e
+regular7=413f39
 
-bright0=#473e37
-bright1=#990f0f
-bright2=#2b551f
-bright3=#6f4011
-bright4=#1d5166
-bright5=#641eb8
-bright6=#2a524c
-bright7=#5d3609
-16=#5b3716
-17=#921d21
+bright0=473e37
+bright1=990f0f
+bright2=2b551f
+bright3=6f4011
+bright4=1d5166
+bright5=641eb8
+bright6=2a524c
+bright7=5d3609
+16=5b3716
+17=921d21

--- a/extras/foot/themes/light/5/oasis_abyss_light_5.ini
+++ b/extras/foot/themes/light/5/oasis_abyss_light_5.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_abyss_light_5.ini
-; name: Oasis Abyss Light 5
-; author: uhs-robert
+# extras/foot/oasis_abyss_light_5.ini
+# name: Oasis Abyss Light 5
+# author: uhs-robert
 
 [colors]
-cursor=#f3d2ba #991c1f
-foreground=#48413b
-background=#f3d2ba
+cursor=f3d2ba 991c1f
+foreground=48413b
+background=f3d2ba
 
-selection-foreground=#48413b
-selection-background=#ecb893
+selection-foreground=48413b
+selection-background=ecb893
 
-search-box-no-match=#4e0e0e #e19d9d
-search-box-match=#0d311d #7ad1a1
+search-box-no-match=4e0e0e e19d9d
+search-box-match=0d311d 7ad1a1
 
-urls=#234756
-jump-labels=#0d311d #7ad1a1
+urls=234756
+jump-labels=0d311d 7ad1a1
 
-regular0=#424242
-regular1=#9f0f0f
-regular2=#27583e
-regular3=#554f1c
-regular4=#11508d
-regular5=#691fbe
-regular6=#2c5651
-regular7=#45433c
+regular0=424242
+regular1=9f0f0f
+regular2=27583e
+regular3=554f1c
+regular4=11508d
+regular5=691fbe
+regular6=2c5651
+regular7=45433c
 
-bright0=#4a4139
-bright1=#9e0f0f
-bright2=#2c5920
-bright3=#744211
-bright4=#1e546a
-bright5=#681fbf
-bright6=#2b564f
-bright7=#62390a
-16=#5f3a17
-17=#564f24
+bright0=4a4139
+bright1=9e0f0f
+bright2=2c5920
+bright3=744211
+bright4=1e546a
+bright5=681fbf
+bright6=2b564f
+bright7=62390a
+16=5f3a17
+17=564f24

--- a/extras/foot/themes/light/5/oasis_cactus_light_5.ini
+++ b/extras/foot/themes/light/5/oasis_cactus_light_5.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_cactus_light_5.ini
-; name: Oasis Cactus Light 5
-; author: uhs-robert
+# extras/foot/oasis_cactus_light_5.ini
+# name: Oasis Cactus Light 5
+# author: uhs-robert
 
 [colors]
-cursor=#cbebd7 #375e39
-foreground=#3c4d44
-background=#cbebd7
+cursor=cbebd7 375e39
+foreground=3c4d44
+background=cbebd7
 
-selection-foreground=#3c4d44
-selection-background=#aadebe
+selection-foreground=3c4d44
+selection-background=aadebe
 
-search-box-no-match=#15472f #a4dac0
-search-box-match=#350808 #dd6f6f
+search-box-no-match=15472f a4dac0
+search-box-match=350808 dd6f6f
 
-urls=#274e5e
-jump-labels=#350808 #dd6f6f
+urls=274e5e
+jump-labels=350808 dd6f6f
 
-regular0=#494949
-regular1=#ac1111
-regular2=#2a5f43
-regular3=#5c561f
-regular4=#135699
-regular5=#7222ce
-regular6=#305d57
-regular7=#4c4942
+regular0=494949
+regular1=ac1111
+regular2=2a5f43
+regular3=5c561f
+regular4=135699
+regular5=7222ce
+regular6=305d57
+regular7=4c4942
 
-bright0=#51483f
-bright1=#ac1111
-bright2=#306023
-bright3=#7e4813
-bright4=#215b73
-bright5=#7022cf
-bright6=#2f5d56
-bright7=#6b3f0b
-16=#694019
-17=#a22527
+bright0=51483f
+bright1=ac1111
+bright2=306023
+bright3=7e4813
+bright4=215b73
+bright5=7022cf
+bright6=2f5d56
+bright7=6b3f0b
+16=694019
+17=a22527

--- a/extras/foot/themes/light/5/oasis_canyon_light_5.ini
+++ b/extras/foot/themes/light/5/oasis_canyon_light_5.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_canyon_light_5.ini
-; name: Oasis Canyon Light 5
-; author: uhs-robert
+# extras/foot/oasis_canyon_light_5.ini
+# name: Oasis Canyon Light 5
+# author: uhs-robert
 
 [colors]
-cursor=#f3d5ba #7c400d
-foreground=#52412d
-background=#f3d5ba
+cursor=f3d5ba 7c400d
+foreground=52412d
+background=f3d5ba
 
-selection-foreground=#52412d
-selection-background=#ecbd93
+selection-foreground=52412d
+selection-background=ecbd93
 
-search-box-no-match=#4e260e #e1b69d
-search-box-match=#092234 #72aeda
+search-box-no-match=4e260e e1b69d
+search-box-match=092234 72aeda
 
-urls=#244857
-jump-labels=#092234 #72aeda
+urls=244857
+jump-labels=092234 72aeda
 
-regular0=#444444
-regular1=#a11010
-regular2=#28593f
-regular3=#56511d
-regular4=#11518f
-regular5=#6b1fc2
-regular6=#2d5752
-regular7=#46443d
+regular0=444444
+regular1=a11010
+regular2=28593f
+regular3=56511d
+regular4=11518f
+regular5=6b1fc2
+regular6=2d5752
+regular7=46443d
 
-bright0=#4b423a
-bright1=#a11010
-bright2=#2d5a20
-bright3=#764311
-bright4=#1f566c
-bright5=#6a20c2
-bright6=#2c5750
-bright7=#643a0a
-16=#613b18
-17=#9b1e22
+bright0=4b423a
+bright1=a11010
+bright2=2d5a20
+bright3=764311
+bright4=1f566c
+bright5=6a20c2
+bright6=2c5750
+bright7=643a0a
+16=613b18
+17=9b1e22

--- a/extras/foot/themes/light/5/oasis_desert_light_5.ini
+++ b/extras/foot/themes/light/5/oasis_desert_light_5.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_desert_light_5.ini
-; name: Oasis Desert Light 5
-; author: uhs-robert
+# extras/foot/oasis_desert_light_5.ini
+# name: Oasis Desert Light 5
+# author: uhs-robert
 
 [colors]
-cursor=#f3d5ba #595016
-foreground=#504132
-background=#f3d5ba
+cursor=f3d5ba 595016
+foreground=504132
+background=f3d5ba
 
-selection-foreground=#504132
-selection-background=#ecbd93
+selection-foreground=504132
+selection-background=ecbd93
 
-search-box-no-match=#473c15 #dacfa4
-search-box-match=#351908 #dd986f
+search-box-no-match=473c15 dacfa4
+search-box-match=351908 dd986f
 
-urls=#244857
-jump-labels=#351908 #dd986f
+urls=244857
+jump-labels=351908 dd986f
 
-regular0=#444444
-regular1=#a11010
-regular2=#28593f
-regular3=#56511d
-regular4=#11518f
-regular5=#6b1fc2
-regular6=#2d5752
-regular7=#46443d
+regular0=444444
+regular1=a11010
+regular2=28593f
+regular3=56511d
+regular4=11518f
+regular5=6b1fc2
+regular6=2d5752
+regular7=46443d
 
-bright0=#4b423a
-bright1=#a11010
-bright2=#2d5a20
-bright3=#764311
-bright4=#1f566c
-bright5=#6a20c2
-bright6=#2c5750
-bright7=#643a0a
-16=#613b18
-17=#9b1e22
+bright0=4b423a
+bright1=a11010
+bright2=2d5a20
+bright3=764311
+bright4=1f566c
+bright5=6a20c2
+bright6=2c5750
+bright7=643a0a
+16=613b18
+17=9b1e22

--- a/extras/foot/themes/light/5/oasis_dune_light_5.ini
+++ b/extras/foot/themes/light/5/oasis_dune_light_5.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_dune_light_5.ini
-; name: Oasis Dune Light 5
-; author: uhs-robert
+# extras/foot/oasis_dune_light_5.ini
+# name: Oasis Dune Light 5
+# author: uhs-robert
 
 [colors]
-cursor=#ece1c6 #5e5517
-foreground=#4a4940
-background=#ece1c6
+cursor=ece1c6 5e5517
+foreground=4a4940
+background=ece1c6
 
-selection-foreground=#4a4940
-selection-background=#e1cfa4
+selection-foreground=4a4940
+selection-background=e1cfa4
 
-search-box-no-match=#473c15 #dacfa4
-search-box-match=#210b32 #ab76d6
+search-box-no-match=473c15 dacfa4
+search-box-match=210b32 ab76d6
 
-urls=#274d5d
-jump-labels=#210b32 #ab76d6
+urls=274d5d
+jump-labels=210b32 ab76d6
 
-regular0=#484848
-regular1=#a91010
-regular2=#2a5e42
-regular3=#5b551e
-regular4=#125597
-regular5=#7021cc
-regular6=#2f5c57
-regular7=#4a4841
+regular0=484848
+regular1=a91010
+regular2=2a5e42
+regular3=5b551e
+regular4=125597
+regular5=7021cc
+regular6=2f5c57
+regular7=4a4841
 
-bright0=#50473e
-bright1=#aa1111
-bright2=#2f5f22
-bright3=#7d4712
-bright4=#215b72
-bright5=#6f22cd
-bright6=#2f5c55
-bright7=#6a3e0b
-16=#683f19
-17=#9f272b
+bright0=50473e
+bright1=aa1111
+bright2=2f5f22
+bright3=7d4712
+bright4=215b72
+bright5=6f22cd
+bright6=2f5c55
+bright7=6a3e0b
+16=683f19
+17=9f272b

--- a/extras/foot/themes/light/5/oasis_lagoon_light_5.ini
+++ b/extras/foot/themes/light/5/oasis_lagoon_light_5.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_lagoon_light_5.ini
-; name: Oasis Lagoon Light 5
-; author: uhs-robert
+# extras/foot/oasis_lagoon_light_5.ini
+# name: Oasis Lagoon Light 5
+# author: uhs-robert
 
 [colors]
-cursor=#bcd6f5 #104d84
-foreground=#30405b
-background=#bcd6f5
+cursor=bcd6f5 104d84
+foreground=30405b
+background=bcd6f5
 
-selection-foreground=#30405b
-selection-background=#94beef
+selection-foreground=30405b
+selection-background=94beef
 
-search-box-no-match=#0f384c #9fcae0
-search-box-match=#351908 #dd986f
+search-box-no-match=0f384c 9fcae0
+search-box-match=351908 dd986f
 
-urls=#224452
-jump-labels=#351908 #dd986f
+urls=224452
+jump-labels=351908 dd986f
 
-regular0=#404040
-regular1=#990f0f
-regular2=#26543c
-regular3=#524d1b
-regular4=#104d88
-regular5=#651eb8
-regular6=#2a524e
-regular7=#413f39
+regular0=404040
+regular1=990f0f
+regular2=26543c
+regular3=524d1b
+regular4=104d88
+regular5=651eb8
+regular6=2a524e
+regular7=413f39
 
-bright0=#463e37
-bright1=#990f0f
-bright2=#2a551f
-bright3=#704010
-bright4=#1d5166
-bright5=#641eb8
-bright6=#2a534c
-bright7=#5d3609
-16=#5b3716
-17=#941b1e
+bright0=463e37
+bright1=990f0f
+bright2=2a551f
+bright3=704010
+bright4=1d5166
+bright5=641eb8
+bright6=2a534c
+bright7=5d3609
+16=5b3716
+17=941b1e

--- a/extras/foot/themes/light/5/oasis_midnight_light_5.ini
+++ b/extras/foot/themes/light/5/oasis_midnight_light_5.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_midnight_light_5.ini
-; name: Oasis Midnight Light 5
-; author: uhs-robert
+# extras/foot/oasis_midnight_light_5.ini
+# name: Oasis Midnight Light 5
+# author: uhs-robert
 
 [colors]
-cursor=#f3cdba #941d21
-foreground=#473f3a
-background=#f3cdba
+cursor=f3cdba 941d21
+foreground=473f3a
+background=f3cdba
 
-selection-foreground=#473f3a
-selection-background=#ecb193
+selection-foreground=473f3a
+selection-background=ecb193
 
-search-box-no-match=#4e0e0e #e19d9d
-search-box-match=#0d311d #7ad1a1
+search-box-no-match=4e0e0e e19d9d
+search-box-match=0d311d 7ad1a1
 
-urls=#224553
-jump-labels=#0d311d #7ad1a1
+urls=224553
+jump-labels=0d311d 7ad1a1
 
-regular0=#404040
-regular1=#9a0f0f
-regular2=#26553c
-regular3=#534d1b
-regular4=#114d89
-regular5=#661eb9
-regular6=#2b534e
-regular7=#42403a
+regular0=404040
+regular1=9a0f0f
+regular2=26553c
+regular3=534d1b
+regular4=114d89
+regular5=661eb9
+regular6=2b534e
+regular7=42403a
 
-bright0=#473f37
-bright1=#9a0f0f
-bright2=#2b561f
-bright3=#714011
-bright4=#1e5267
-bright5=#651fba
-bright6=#2a534d
-bright7=#5f370a
-16=#5c3816
-17=#534d23
+bright0=473f37
+bright1=9a0f0f
+bright2=2b561f
+bright3=714011
+bright4=1e5267
+bright5=651fba
+bright6=2a534d
+bright7=5f370a
+16=5c3816
+17=534d23

--- a/extras/foot/themes/light/5/oasis_mirage_light_5.ini
+++ b/extras/foot/themes/light/5/oasis_mirage_light_5.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_mirage_light_5.ini
-; name: Oasis Mirage Light 5
-; author: uhs-robert
+# extras/foot/oasis_mirage_light_5.ini
+# name: Oasis Mirage Light 5
+# author: uhs-robert
 
 [colors]
-cursor=#c0f2ee #31605a
-foreground=#3c5050
-background=#c0f2ee
+cursor=c0f2ee 31605a
+foreground=3c5050
+background=c0f2ee
 
-selection-foreground=#3c5050
-selection-background=#9aeae4
+selection-foreground=3c5050
+selection-background=9aeae4
 
-search-box-no-match=#0f4c44 #9fe0d7
-search-box-match=#351908 #dd986f
+search-box-no-match=0f4c44 9fe0d7
+search-box-match=351908 dd986f
 
-urls=#295162
-jump-labels=#351908 #dd986f
+urls=295162
+jump-labels=351908 dd986f
 
-regular0=#4c4c4c
-regular1=#b11111
-regular2=#2c6346
-regular3=#605a20
-regular4=#13599f
-regular5=#7523d5
-regular6=#31605b
-regular7=#4e4c44
+regular0=4c4c4c
+regular1=b11111
+regular2=2c6346
+regular3=605a20
+regular4=13599f
+regular5=7523d5
+regular6=31605b
+regular7=4e4c44
 
-bright0=#554a41
-bright1=#b11111
-bright2=#316424
-bright3=#834b13
-bright4=#225f77
-bright5=#7423d6
-bright6=#316159
-bright7=#70410b
-16=#6d421a
-17=#a82628
+bright0=554a41
+bright1=b11111
+bright2=316424
+bright3=834b13
+bright4=225f77
+bright5=7423d6
+bright6=316159
+bright7=70410b
+16=6d421a
+17=a82628

--- a/extras/foot/themes/light/5/oasis_night_light_5.ini
+++ b/extras/foot/themes/light/5/oasis_night_light_5.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_night_light_5.ini
-; name: Oasis Night Light 5
-; author: uhs-robert
+# extras/foot/oasis_night_light_5.ini
+# name: Oasis Night Light 5
+# author: uhs-robert
 
 [colors]
-cursor=#e0cfa3 #723b0c
-foreground=#4b3b28
-background=#e0cfa3
+cursor=e0cfa3 723b0c
+foreground=4b3b28
+background=e0cfa3
 
-selection-foreground=#4b3b28
-selection-background=#d5bd81
+selection-foreground=4b3b28
+selection-background=d5bd81
 
-search-box-no-match=#4e260e #e1b69d
-search-box-match=#350808 #dd6f6f
+search-box-no-match=4e260e e1b69d
+search-box-match=350808 dd6f6f
 
-urls=#21414f
-jump-labels=#350808 #dd6f6f
+urls=21414f
+jump-labels=350808 dd6f6f
 
-regular0=#583512
-regular1=#950e0e
-regular2=#24523a
-regular3=#504b1a
-regular4=#104b84
-regular5=#621db3
-regular6=#29504b
-regular7=#3f3d37
+regular0=583512
+regular1=950e0e
+regular2=24523a
+regular3=504b1a
+regular4=104b84
+regular5=621db3
+regular6=29504b
+regular7=3f3d37
 
-bright0=#4e392c
-bright1=#950e0e
-bright2=#29531e
-bright3=#6d3e10
-bright4=#1d4f63
-bright5=#621eb4
-bright6=#29504a
-bright7=#5a3509
-16=#583515
-17=#8f1c20
+bright0=4e392c
+bright1=950e0e
+bright2=29531e
+bright3=6d3e10
+bright4=1d4f63
+bright5=621eb4
+bright6=29504a
+bright7=5a3509
+16=583515
+17=8f1c20

--- a/extras/foot/themes/light/5/oasis_rose_light_5.ini
+++ b/extras/foot/themes/light/5/oasis_rose_light_5.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_rose_light_5.ini
-; name: Oasis Rose Light 5
-; author: uhs-robert
+# extras/foot/oasis_rose_light_5.ini
+# name: Oasis Rose Light 5
+# author: uhs-robert
 
 [colors]
-cursor=#f0c2e7 #941015
-foreground=#4a3845
-background=#f0c2e7
+cursor=f0c2e7 941015
+foreground=4a3845
+background=f0c2e7
 
-selection-foreground=#4a3845
-selection-background=#e79dd9
+selection-foreground=4a3845
+selection-background=e79dd9
 
-search-box-no-match=#481335 #dba3c6
-search-box-match=#09342f #72dacc
+search-box-no-match=481335 dba3c6
+search-box-match=09342f 72dacc
 
-urls=#21414f
-jump-labels=#09342f #72dacc
+urls=21414f
+jump-labels=09342f 72dacc
 
-regular0=#3d3d3d
-regular1=#950e0e
-regular2=#24523a
-regular3=#4f4a1a
-regular4=#104a84
-regular5=#621db2
-regular6=#29504b
-regular7=#3f3d37
+regular0=3d3d3d
+regular1=950e0e
+regular2=24523a
+regular3=4f4a1a
+regular4=104a84
+regular5=621db2
+regular6=29504b
+regular7=3f3d37
 
-bright0=#443c35
-bright1=#940e0e
-bright2=#29531e
-bright3=#6d3e10
-bright4=#1c4f63
-bright5=#611db3
-bright6=#29504a
-bright7=#5a3509
-16=#583515
-17=#504a21
+bright0=443c35
+bright1=940e0e
+bright2=29531e
+bright3=6d3e10
+bright4=1c4f63
+bright5=611db3
+bright6=29504a
+bright7=5a3509
+16=583515
+17=504a21

--- a/extras/foot/themes/light/5/oasis_sol_light_5.ini
+++ b/extras/foot/themes/light/5/oasis_sol_light_5.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_sol_light_5.ini
-; name: Oasis Sol Light 5
-; author: uhs-robert
+# extras/foot/oasis_sol_light_5.ini
+# name: Oasis Sol Light 5
+# author: uhs-robert
 
 [colors]
-cursor=#f3bfba #871f20
-foreground=#5b2e26
-background=#f3bfba
+cursor=f3bfba 871f20
+foreground=5b2e26
+background=f3bfba
 
-selection-foreground=#5b2e26
-selection-background=#ec9b93
+selection-foreground=5b2e26
+selection-background=ec9b93
 
-search-box-no-match=#4e0e0e #e19d9d
-search-box-match=#0d311f #7ad1a7
+search-box-no-match=4e0e0e e19d9d
+search-box-match=0d311f 7ad1a7
 
-urls=#1f3e4b
-jump-labels=#0d311f #7ad1a7
+urls=1f3e4b
+jump-labels=0d311f 7ad1a7
 
-regular0=#3a3a3a
-regular1=#8f0e0e
-regular2=#234f38
-regular3=#4c4719
-regular4=#0f477f
-regular5=#5e1cab
-regular6=#274d48
-regular7=#3c3a34
+regular0=3a3a3a
+regular1=8f0e0e
+regular2=234f38
+regular3=4c4719
+regular4=0f477f
+regular5=5e1cab
+regular6=274d48
+regular7=3c3a34
 
-bright0=#413932
-bright1=#8f0e0e
-bright2=#274f1d
-bright3=#683b0f
-bright4=#1b4b5f
-bright5=#5d1cac
-bright6=#274d47
-bright7=#563209
-16=#543314
-17=#4d4720
+bright0=413932
+bright1=8f0e0e
+bright2=274f1d
+bright3=683b0f
+bright4=1b4b5f
+bright5=5d1cac
+bright6=274d47
+bright7=563209
+16=543314
+17=4d4720

--- a/extras/foot/themes/light/5/oasis_starlight_light_5.ini
+++ b/extras/foot/themes/light/5/oasis_starlight_light_5.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_starlight_light_5.ini
-; name: Oasis Starlight Light 5
-; author: uhs-robert
+# extras/foot/oasis_starlight_light_5.ini
+# name: Oasis Starlight Light 5
+# author: uhs-robert
 
 [colors]
-cursor=#f3deba #125592
-foreground=#4d4738
-background=#f3deba
+cursor=f3deba 125592
+foreground=4d4738
+background=f3deba
 
-selection-foreground=#4d4738
-selection-background=#eccb93
+selection-foreground=4d4738
+selection-background=eccb93
 
-search-box-no-match=#473c15 #dacfa4
-search-box-match=#351908 #dd986f
+search-box-no-match=473c15 dacfa4
+search-box-match=351908 dd986f
 
-urls=#264c5c
-jump-labels=#351908 #dd986f
+urls=264c5c
+jump-labels=351908 dd986f
 
-regular0=#474747
-regular1=#a81010
-regular2=#2a5d42
-regular3=#5b551e
-regular4=#125596
-regular5=#6f21ca
-regular6=#2f5b56
-regular7=#4a4740
+regular0=474747
+regular1=a81010
+regular2=2a5d42
+regular3=5b551e
+regular4=125596
+regular5=6f21ca
+regular6=2f5b56
+regular7=4a4740
 
-bright0=#4f463d
-bright1=#a81010
-bright2=#2f5e22
-bright3=#7c4712
-bright4=#205a71
-bright5=#6e21cb
-bright6=#2e5b54
-bright7=#693d0b
-16=#673e19
-17=#a81218
+bright0=4f463d
+bright1=a81010
+bright2=2f5e22
+bright3=7c4712
+bright4=205a71
+bright5=6e21cb
+bright6=2e5b54
+bright7=693d0b
+16=673e19
+17=a81218

--- a/extras/foot/themes/light/5/oasis_twilight_light_5.ini
+++ b/extras/foot/themes/light/5/oasis_twilight_light_5.ini
@@ -1,37 +1,37 @@
-; extras/foot/oasis_twilight_light_5.ini
-; name: Oasis Twilight Light 5
-; author: uhs-robert
+# extras/foot/oasis_twilight_light_5.ini
+# name: Oasis Twilight Light 5
+# author: uhs-robert
 
 [colors]
-cursor=#cac2f0 #6012a9
-foreground=#3b3351
-background=#cac2f0
+cursor=cac2f0 6012a9
+foreground=3b3351
+background=cac2f0
 
-selection-foreground=#3b3351
-selection-background=#aa9de7
+selection-foreground=3b3351
+selection-background=aa9de7
 
-search-box-no-match=#31124a #c3a1dd
-search-box-match=#31290d #d1be7a
+search-box-no-match=31124a c3a1dd
+search-box-match=31290d d1be7a
 
-urls=#1e3b48
-jump-labels=#31290d #d1be7a
+urls=1e3b48
+jump-labels=31290d d1be7a
 
-regular0=#383838
-regular1=#8b0d0d
-regular2=#224c36
-regular3=#4a4518
-regular4=#0f457b
-regular5=#5b1ba6
-regular6=#264a46
-regular7=#393832
+regular0=383838
+regular1=8b0d0d
+regular2=224c36
+regular3=4a4518
+regular4=0f457b
+regular5=5b1ba6
+regular6=264a46
+regular7=393832
 
-bright0=#3e3630
-bright1=#8a0d0d
-bright2=#264d1c
-bright3=#653a0f
-bright4=#1a495c
-bright5=#5a1ba6
-bright6=#264a45
-bright7=#523008
-16=#503013
-17=#851a1d
+bright0=3e3630
+bright1=8a0d0d
+bright2=264d1c
+bright3=653a0f
+bright4=1a495c
+bright5=5a1ba6
+bright6=264a45
+bright7=523008
+16=503013
+17=851a1d


### PR DESCRIPTION
### Background

foot `1.25.0 +pgo +ime +graphemes -assertions` requires `#` as the comment symbol ,bare `RRGGBB` hex for color values (no `#` prefix) , and `include=xxx` syntax for including theme files.

The generated `.ini` files used `;` for comments and `#RRGGBB` format, causing the following errors:
```
error: foot: /home/user/.config/foot/themes/oasis/dark/oasis_lagoon_dark.ini:1: [main].; extras/foot/oasis_lagoon_dark.ini: syntax error: key/value pair has no value
error: foot: /home/user/.config/foot/themes/oasis/dark/oasis_lagoon_dark.ini:2: [main:].; name: Oasis Lagoon Dark: syntax error: key/value pair has no value
error: foot: /home/user/.config/foot/themes/oasis/dark/oasis_lagoon_dark.ini:3: [main:].; author: uhs-robert: syntax error: key/value pair has no value
error: foot: /home/user/.config/foot/themes/oasis/dark/oasis_lagoon_dark.ini:6: [colors].cursor: #101825: invalid double color value
error: foot: /home/user/.config/foot/themes/oasis/dark/oasis_lagoon_dark.ini:7: [colors:].foreground: #D9E6FA: color must be in RGB format
error: foot: /home/user/.config/foot/themes/oasis/dark/oasis_lagoon_dark.ini:8: [colors:].background: #101825: color must be in RGB format
...
```

### Changes
- Replace `;` comment symbol with `#`
- Strip `#` prefix from all color values
- Fix `include xxx` to `include=xxx` syntax in README example