### PR TITLE
fix(theme): distinguish active tabs in affected palettes

### DIFF
--- a/lua/oasis/color_palettes/oasis_abyss.lua
+++ b/lua/oasis/color_palettes/oasis_abyss.lua
@@ -29,6 +29,7 @@ local base = {
     title = p.red[800],
     accent = p.palm[500],
     cursor = p.khaki[500],
+    tabline_current = p.red[500],
   },
 }
 

--- a/lua/oasis/color_palettes/oasis_desert.lua
+++ b/lua/oasis/color_palettes/oasis_desert.lua
@@ -30,6 +30,7 @@ local base = {
     title = p.red[800],
     accent = p.palm[500],
     cursor = p.khaki[500],
+    tabline_current = p.red[500],
   },
 }
 

--- a/lua/oasis/color_palettes/oasis_midnight.lua
+++ b/lua/oasis/color_palettes/oasis_midnight.lua
@@ -29,6 +29,7 @@ local base = {
     title = p.red[800],
     accent = p.palm[500],
     cursor = p.khaki[500],
+    tabline_current = p.red[500],
   },
 }
 

--- a/lua/oasis/theme_generator.lua
+++ b/lua/oasis/theme_generator.lua
@@ -507,10 +507,11 @@ local PLUGIN_GROUPS = {
     hl.MiniStatuslineInactive = { fg = c.fg.comment, bg = c.bg.surface }
 
     -- Mini Tabline
-    hl.MiniTablineCurrent = { fg = theme.secondary, bg = c.bg.surface, bold = true }
+    local tabline_current = c.theme.tabline_current or theme.secondary
+    hl.MiniTablineCurrent = { fg = tabline_current, bg = c.bg.surface, bold = true }
     hl.MiniTablineFill = "TabLineFill"
     hl.MiniTablineHidden = "TabLine"
-    hl.MiniTablineModifiedCurrent = { fg = c.bg.core, bg = theme.secondary, bold = true }
+    hl.MiniTablineModifiedCurrent = { fg = c.bg.core, bg = tabline_current, bold = true }
     hl.MiniTablineModifiedHidden = { fg = c.bg.core, bg = c.ui.border }
     hl.MiniTablineModifiedVisible = { fg = c.bg.core, bg = c.ui.border, bold = true }
     hl.MiniTablineTabpagesection = { fg = c.bg.core, bg = c.theme.accent }

--- a/lua/oasis/types.lua
+++ b/lua/oasis/types.lua
@@ -28,6 +28,7 @@
 ---@field label? string
 ---@field accent string
 ---@field cursor string
+---@field tabline_current? string
 
 ---@class OasisPaletteSyntax
 ---@field parameter string
@@ -317,6 +318,7 @@
 ---@field accent? string
 ---@field strong_primary? string
 ---@field light_primary? string
+---@field tabline_current? string
 
 ---@class OasisPaletteSyntaxOverrides
 ---@field parameter? string


### PR DESCRIPTION
## Summary

- add an optional palette-level color for the current MiniTabline entry
- use it for both current and modified-current tabs
- set Abyss, Desert, and Midnight to their red secondary color while preserving the existing fallback for other palettes

## Why

The theme-role refactor maps the current tab in these palettes to a khaki color that is close to the hidden tab color, especially when bold styling is disabled. Palette-local values restore a distinct red active state without changing Scorpion, Sol, or unrelated themes.

Fixes #42.

## Verification

- targeted StyLua checks for all changed files
- headless Neovim 0.12.4 checks with bold disabled and enabled
- Abyss, Desert, Midnight, Scorpion, and Sol checked in dark and light modes
- all 16 palettes checked in both dark and light modes (32 combinations)
- 100-run startup benchmark
- `git diff --check`
