### PR TITLE
feat(extras): add Windows Terminal and PSReadLine theme generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,38 +149,40 @@ To use the extras, refer to their respective documentation.
 
 <!-- extras:start -->
 
-| Tool        | Extra                                                  |
-| ----------- | ------------------------------------------------------ |
-| Alacritty   | [extras/alacritty](extras/alacritty)                   |
-| Bat         | [extras/bat](extras/bat)                               |
-| Btop        | [extras/btop](extras/btop)                             |
-| Dark Reader | [extras/dark-reader](/extras/dark-reader)              |
-| Firefox     | [extras/firefox](extras/firefox)                       |
-| Foot        | [extras/foot](extras/foot)                             |
-| FZF         | [extras/fzf](extras/fzf)                               |
-| Gemini CLI  | [extras/gemini-cli](extras/gemini-cli)                 |
-| Ghostty     | [extras/ghostty](extras/ghostty)                       |
-| iTerm       | [extras/iterm](extras/iterm)                           |
-| JSON-theme  | [extras/json-theme](/extras/json-theme)                |
-| Kitty       | [extras/kitty](extras/kitty)                           |
-| Konsole     | [extras/konsole](extras/konsole)                       |
-| LazyGit     | [extras/lazygit](extras/lazygit)                       |
-| Lua-theme   | [extras/lua-theme](/extras/lua-theme)                  |
-| Nless       | [extras/nless](/extras/nless)                          |
-| Qutebrowser | [extras/qutebrowser](extras/qutebrowser)               |
-| Slack       | [extras/slack](extras/slack)                           |
-| Starship    | [extras/starship](extras/starship)                     |
-| Termux      | [extras/termux](extras/termux)                         |
-| Thunderbird | [extras/thunderbird](extras/thunderbird)               |
-| Tridactyl   | [extras/tridactyl](extras/tridactyl)                   |
-| TMUX        | [tmux-oasis](https://github.com/uhs-robert/tmux-oasis) |
-| Vimium      | [extras/vimium](extras/vimium)                         |
-| Vimium C    | [extras/vimium-c](extras/vimium-c)                     |
-| VS Code     | [extras/vscode](extras/vscode)                         |
-| Warp        | [extras/warp](extras/warp)                             |
-| WezTerm     | [extras/wezterm](extras/wezterm)                       |
-| Yazi        | [extras/yazi](extras/yazi)                             |
-| Zed         | [extras/zed](extras/zed)                               |
+| Tool             | Extra                                                  |
+| ---------------- | ------------------------------------------------------ |
+| Alacritty        | [extras/alacritty](extras/alacritty)                   |
+| Bat              | [extras/bat](extras/bat)                               |
+| Btop             | [extras/btop](extras/btop)                             |
+| Dark Reader      | [extras/dark-reader](/extras/dark-reader)              |
+| Firefox          | [extras/firefox](extras/firefox)                       |
+| Foot             | [extras/foot](extras/foot)                             |
+| FZF              | [extras/fzf](extras/fzf)                               |
+| Gemini CLI       | [extras/gemini-cli](extras/gemini-cli)                 |
+| Ghostty          | [extras/ghostty](extras/ghostty)                       |
+| iTerm            | [extras/iterm](extras/iterm)                           |
+| JSON-theme       | [extras/json-theme](/extras/json-theme)                |
+| Kitty            | [extras/kitty](extras/kitty)                           |
+| Konsole          | [extras/konsole](extras/konsole)                       |
+| LazyGit          | [extras/lazygit](extras/lazygit)                       |
+| Lua-theme        | [extras/lua-theme](/extras/lua-theme)                  |
+| Nless            | [extras/nless](/extras/nless)                          |
+| PSReadLine       | [extras/psreadline](extras/psreadline)                 |
+| Qutebrowser      | [extras/qutebrowser](extras/qutebrowser)               |
+| Slack            | [extras/slack](extras/slack)                           |
+| Starship         | [extras/starship](extras/starship)                     |
+| Termux           | [extras/termux](extras/termux)                         |
+| Thunderbird      | [extras/thunderbird](extras/thunderbird)               |
+| Tridactyl        | [extras/tridactyl](extras/tridactyl)                   |
+| TMUX             | [tmux-oasis](https://github.com/uhs-robert/tmux-oasis) |
+| Vimium           | [extras/vimium](extras/vimium)                         |
+| Vimium C         | [extras/vimium-c](extras/vimium-c)                     |
+| VS Code          | [extras/vscode](extras/vscode)                         |
+| Warp             | [extras/warp](extras/warp)                             |
+| WezTerm          | [extras/wezterm](extras/wezterm)                       |
+| Windows Terminal | [extras/windows-terminal](extras/windows-terminal)     |
+| Yazi             | [extras/yazi](extras/yazi)                             |
+| Zed              | [extras/zed](extras/zed)                               |
 
 If you'd like an extra config added, raise a feature request and I'll put it together.
 

--- a/extras/psreadline/README.md
+++ b/extras/psreadline/README.md
@@ -1,0 +1,30 @@
+# PSReadLine Setup
+
+PSReadLine themes are PowerShell scripts that call `Set-PSReadLineOption -Colors @{ ... }` with 24-bit truecolor ANSI escapes for the exact Oasis palette.
+
+> [!NOTE]
+> These are truecolor escape sequences and require a truecolor-capable host — Windows Terminal qualifies, but the legacy `conhost` console does not. PSReadLine 2.x is required.
+
+### Installation
+
+Copy the `.ps1` file for the variant you want somewhere you'll remember, for example:
+
+```powershell
+Copy-Item themes\dark\oasis_mirage_dark.ps1 "$HOME\Documents\PowerShell\oasis_mirage_dark.ps1"
+```
+
+### Usage
+
+Dot-source it from your `$PROFILE` so it loads on every new session:
+
+```powershell
+. "$HOME\Documents\PowerShell\oasis_mirage_dark.ps1"
+```
+
+Reload PowerShell (or re-dot-source the file) to apply it immediately.
+
+### Theme Structure
+
+- **Dark themes**: `themes/dark/oasis_<variant>_dark.ps1`
+- **Light themes**: `themes/light/<intensity>/oasis_<variant>_light_<intensity>.ps1`
+  - Intensity levels: `1` (lightest) to `5` (darkest)

--- a/extras/psreadline/generate_psreadline.lua
+++ b/extras/psreadline/generate_psreadline.lua
@@ -1,0 +1,102 @@
+#!/usr/bin/env lua
+-- extras/psreadline/generate_psreadline.lua
+-- Generates PSReadLine truecolor theme scripts from Oasis color palettes
+
+package.path = package.path .. ";./lua/?.lua;./lua/?/init.lua"
+local Utils = require("oasis.utils")
+local File = require("oasis.lib.file")
+local ColorUtils = require("oasis.tools.color_utils")
+
+--- Fail loudly instead of writing a malformed file with a missing color.
+--- @param value string|nil Hex color pulled from the palette
+--- @param label string Token name, used in the error message
+--- @return string value The verified hex color
+local function require_color(value, label)
+  if value == nil then error(string.format("Missing palette color for token '%s'", label)) end
+  return value
+end
+
+--- @param hex string Hex color (e.g. "#RRGGBB")
+--- @param mode "38"|"48" ANSI mode: 38 for foreground, 48 for background
+--- @return string escape PowerShell-interpolated truecolor escape sequence
+local function ansi_escape(hex, mode)
+  local rgb = ColorUtils.hex_to_rgb(hex):gsub(",", ";")
+  return string.format('"$esc[%s;2;%sm"', mode, rgb)
+end
+
+local function generate_psreadline_theme(variant_name, palette, output_path)
+  local display_name = Utils.format_display_name(variant_name)
+  -- palette.ui.visual.fg is the Neovim sentinel "none" (inherit), not a real
+  -- color, so fall back to the normal foreground for selection-style tokens.
+  local selection_fg = palette.fg.core
+
+  -- stylua: ignore start
+  local tokens = {
+    { "Command",                require_color(palette.syntax.func, "Command") },
+    { "Comment",                require_color(palette.syntax.comment, "Comment") },
+    { "ContinuationPrompt",     require_color(palette.fg.muted, "ContinuationPrompt") },
+    { "Default",                require_color(palette.fg.core, "Default") },
+    { "Emphasis",               require_color(palette.theme.accent, "Emphasis") },
+    { "Error",                  require_color(palette.ui.diag.error.fg, "Error") },
+    { "InlinePrediction",       require_color(palette.fg.dim, "InlinePrediction") },
+    { "Keyword",                require_color(palette.syntax.statement, "Keyword") },
+    { "ListPrediction",         require_color(palette.fg.dim, "ListPrediction") },
+    { "ListPredictionTooltip",  require_color(palette.fg.dim, "ListPredictionTooltip") },
+    { "Member",                 require_color(palette.syntax.identifier, "Member") },
+    { "Number",                 require_color(palette.syntax.constant, "Number") },
+    { "Operator",               require_color(palette.syntax.operator, "Operator") },
+    { "Parameter",              require_color(palette.syntax.parameter, "Parameter") },
+    { "String",                 require_color(palette.syntax.string, "String") },
+    { "Type",                   require_color(palette.syntax.type, "Type") },
+    { "Variable",               require_color(palette.syntax.builtin_var, "Variable") },
+  }
+  -- stylua: ignore end
+
+  local bg = require_color(palette.ui.visual.bg, "ListPredictionSelected/Selection background")
+  local fg = require_color(selection_fg, "ListPredictionSelected/Selection foreground")
+  local selected = ansi_escape(bg, "48") .. " + " .. ansi_escape(fg, "38")
+
+  local lines = {
+    "# " .. output_path,
+    string.format("## name: %s", display_name),
+    "## author: uhs-robert",
+    "",
+    "$esc = [char]0x1B",
+    "",
+    "Set-PSReadLineOption -Colors @{",
+  }
+
+  for _, token in ipairs(tokens) do
+    lines[#lines + 1] = string.format("  %-23s = %s", token[1], ansi_escape(token[2], "38"))
+  end
+  lines[#lines + 1] = string.format("  %-23s = %s", "ListPredictionSelected", selected)
+  lines[#lines + 1] = string.format("  %-23s = %s", "Selection", selected)
+  lines[#lines + 1] = "}"
+
+  return table.concat(lines, "\n")
+end
+
+local function main()
+  print("\n=== Oasis PSReadLine Theme Generator ===\n")
+
+  local palette_names = Utils.get_palette_names()
+  if #palette_names == 0 then
+    print("Error: No palette files found in lua/oasis/color_palettes/")
+    return
+  end
+
+  print(string.format("Found %d palette(s)\n", #palette_names))
+
+  local success_count, error_count = Utils.for_each_palette_variant(function(name, palette, mode, intensity)
+    local output_path, variant_name = Utils.build_variant_path("extras/psreadline", "ps1", name, mode, intensity)
+    local theme = generate_psreadline_theme(variant_name, palette, output_path)
+    File.write(output_path, theme)
+    print(string.format("✓ Generated: %s", output_path))
+  end)
+
+  print(string.format("\n=== Summary ==="))
+  print(string.format("Success: %d", success_count))
+  print(string.format("Errors: %d\n", error_count))
+end
+
+main()

--- a/extras/psreadline/themes/dark/oasis_abyss_dark.ps1
+++ b/extras/psreadline/themes/dark/oasis_abyss_dark.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/dark/oasis_abyss_dark.ps1
+## name: Oasis Abyss Dark
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;233;192;165m"
+  Comment                 = "$esc[38;2;122;118;98m"
+  ContinuationPrompt      = "$esc[38;2;96;92;77m"
+  Default                 = "$esc[38;2;245;245;220m"
+  Emphasis                = "$esc[38;2;127;207;120m"
+  Error                   = "$esc[38;2;255;160;160m"
+  InlinePrediction        = "$esc[38;2;123;120;109m"
+  Keyword                 = "$esc[38;2;216;207;127m"
+  ListPrediction          = "$esc[38;2;123;120;109m"
+  ListPredictionTooltip   = "$esc[38;2;123;120;109m"
+  Member                  = "$esc[38;2;135;206;235m"
+  Number                  = "$esc[38;2;255;150;51m"
+  Operator                = "$esc[38;2;205;198;115m"
+  Parameter               = "$esc[38;2;127;207;120m"
+  String                  = "$esc[38;2;255;160;160m"
+  Type                    = "$esc[38;2;124;205;181m"
+  Variable                = "$esc[38;2;194;142;255m"
+  ListPredictionSelected  = "$esc[48;2;83;46;46m" + "$esc[38;2;245;245;220m"
+  Selection               = "$esc[48;2;83;46;46m" + "$esc[38;2;245;245;220m"
+}

--- a/extras/psreadline/themes/dark/oasis_cactus_dark.ps1
+++ b/extras/psreadline/themes/dark/oasis_cactus_dark.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/dark/oasis_cactus_dark.ps1
+## name: Oasis Cactus Dark
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;233;192;165m"
+  Comment                 = "$esc[38;2;105;149;109m"
+  ContinuationPrompt      = "$esc[38;2;91;115;96m"
+  Default                 = "$esc[38;2;245;245;220m"
+  Emphasis                = "$esc[38;2;255;160;160m"
+  Error                   = "$esc[38;2;255;160;160m"
+  InlinePrediction        = "$esc[38;2;116;132;119m"
+  Keyword                 = "$esc[38;2;174;214;176m"
+  ListPrediction          = "$esc[38;2;116;132;119m"
+  ListPredictionTooltip   = "$esc[38;2;116;132;119m"
+  Member                  = "$esc[38;2;135;206;235m"
+  Number                  = "$esc[38;2;255;163;77m"
+  Operator                = "$esc[38;2;167;211;169m"
+  Parameter               = "$esc[38;2;255;208;92m"
+  String                  = "$esc[38;2;255;160;160m"
+  Type                    = "$esc[38;2;124;205;181m"
+  Variable                = "$esc[38;2;194;142;255m"
+  ListPredictionSelected  = "$esc[48;2;47;61;51m" + "$esc[38;2;245;245;220m"
+  Selection               = "$esc[48;2;47;61;51m" + "$esc[38;2;245;245;220m"
+}

--- a/extras/psreadline/themes/dark/oasis_canyon_dark.ps1
+++ b/extras/psreadline/themes/dark/oasis_canyon_dark.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/dark/oasis_canyon_dark.ps1
+## name: Oasis Canyon Dark
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;240;230;140m"
+  Comment                 = "$esc[38;2;182;126;97m"
+  ContinuationPrompt      = "$esc[38;2;154;101;73m"
+  Default                 = "$esc[38;2;245;245;220m"
+  Emphasis                = "$esc[38;2;255;144;144m"
+  Error                   = "$esc[38;2;255;160;160m"
+  InlinePrediction        = "$esc[38;2;137;124;117m"
+  Keyword                 = "$esc[38;2;249;175;150m"
+  ListPrediction          = "$esc[38;2;137;124;117m"
+  ListPredictionTooltip   = "$esc[38;2;137;124;117m"
+  Member                  = "$esc[38;2;135;206;235m"
+  Number                  = "$esc[38;2;255;163;77m"
+  Operator                = "$esc[38;2;249;175;150m"
+  Parameter               = "$esc[38;2;127;207;120m"
+  String                  = "$esc[38;2;255;160;160m"
+  Type                    = "$esc[38;2;124;205;181m"
+  Variable                = "$esc[38;2;203;158;255m"
+  ListPredictionSelected  = "$esc[48;2;72;50;40m" + "$esc[38;2;245;245;220m"
+  Selection               = "$esc[48;2;72;50;40m" + "$esc[38;2;245;245;220m"
+}

--- a/extras/psreadline/themes/dark/oasis_desert_dark.ps1
+++ b/extras/psreadline/themes/dark/oasis_desert_dark.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/dark/oasis_desert_dark.ps1
+## name: Oasis Desert Dark
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;233;192;165m"
+  Comment                 = "$esc[38;2;148;143;122m"
+  ContinuationPrompt      = "$esc[38;2;119;114;95m"
+  Default                 = "$esc[38;2;245;245;220m"
+  Emphasis                = "$esc[38;2;127;207;120m"
+  Error                   = "$esc[38;2;255;160;160m"
+  InlinePrediction        = "$esc[38;2;135;132;120m"
+  Keyword                 = "$esc[38;2;240;230;140m"
+  ListPrediction          = "$esc[38;2;135;132;120m"
+  ListPredictionTooltip   = "$esc[38;2;135;132;120m"
+  Member                  = "$esc[38;2;135;206;235m"
+  Number                  = "$esc[38;2;255;163;77m"
+  Operator                = "$esc[38;2;216;207;127m"
+  Parameter               = "$esc[38;2;127;207;120m"
+  String                  = "$esc[38;2;255;160;160m"
+  Type                    = "$esc[38;2;124;205;181m"
+  Variable                = "$esc[38;2;203;158;255m"
+  ListPredictionSelected  = "$esc[48;2;67;63;56m" + "$esc[38;2;245;245;220m"
+  Selection               = "$esc[48;2;67;63;56m" + "$esc[38;2;245;245;220m"
+}

--- a/extras/psreadline/themes/dark/oasis_dune_dark.ps1
+++ b/extras/psreadline/themes/dark/oasis_dune_dark.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/dark/oasis_dune_dark.ps1
+## name: Oasis Dune Dark
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;233;192;165m"
+  Comment                 = "$esc[38;2;159;139;121m"
+  ContinuationPrompt      = "$esc[38;2;130;109;90m"
+  Default                 = "$esc[38;2;245;245;220m"
+  Emphasis                = "$esc[38;2;105;195;170m"
+  Error                   = "$esc[38;2;255;160;160m"
+  InlinePrediction        = "$esc[38;2;142;131;122m"
+  Keyword                 = "$esc[38;2;240;230;140m"
+  ListPrediction          = "$esc[38;2;142;131;122m"
+  ListPredictionTooltip   = "$esc[38;2;142;131;122m"
+  Member                  = "$esc[38;2;135;206;235m"
+  Number                  = "$esc[38;2;255;163;77m"
+  Operator                = "$esc[38;2;216;207;127m"
+  Parameter               = "$esc[38;2;127;207;120m"
+  String                  = "$esc[38;2;255;160;160m"
+  Type                    = "$esc[38;2;124;205;181m"
+  Variable                = "$esc[38;2;203;158;255m"
+  ListPredictionSelected  = "$esc[48;2;70;62;52m" + "$esc[38;2;245;245;220m"
+  Selection               = "$esc[48;2;70;62;52m" + "$esc[38;2;245;245;220m"
+}

--- a/extras/psreadline/themes/dark/oasis_lagoon_dark.ps1
+++ b/extras/psreadline/themes/dark/oasis_lagoon_dark.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/dark/oasis_lagoon_dark.ps1
+## name: Oasis Lagoon Dark
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;233;192;165m"
+  Comment                 = "$esc[38;2;77;136;167m"
+  ContinuationPrompt      = "$esc[38;2;59;106;135m"
+  Default                 = "$esc[38;2;245;245;220m"
+  Emphasis                = "$esc[38;2;255;160;160m"
+  Error                   = "$esc[38;2;255;160;160m"
+  InlinePrediction        = "$esc[38;2;114;127;134m"
+  Keyword                 = "$esc[38;2;113;184;255m"
+  ListPrediction          = "$esc[38;2;114;127;134m"
+  ListPredictionTooltip   = "$esc[38;2;114;127;134m"
+  Member                  = "$esc[38;2;165;220;241m"
+  Number                  = "$esc[38;2;255;163;77m"
+  Operator                = "$esc[38;2;129;192;255m"
+  Parameter               = "$esc[38;2;127;207;120m"
+  String                  = "$esc[38;2;255;160;160m"
+  Type                    = "$esc[38;2;243;234;159m"
+  Variable                = "$esc[38;2;194;142;255m"
+  ListPredictionSelected  = "$esc[48;2;34;56;92m" + "$esc[38;2;245;245;220m"
+  Selection               = "$esc[48;2;34;56;92m" + "$esc[38;2;245;245;220m"
+}

--- a/extras/psreadline/themes/dark/oasis_luna_dark.ps1
+++ b/extras/psreadline/themes/dark/oasis_luna_dark.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/dark/oasis_luna_dark.ps1
+## name: Oasis Luna Dark
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;233;192;165m"
+  Comment                 = "$esc[38;2;162;154;201m"
+  ContinuationPrompt      = "$esc[38;2;138;130;179m"
+  Default                 = "$esc[38;2;245;245;220m"
+  Emphasis                = "$esc[38;2;109;206;235m"
+  Error                   = "$esc[38;2;255;160;160m"
+  InlinePrediction        = "$esc[38;2;124;120;140m"
+  Keyword                 = "$esc[38;2;216;207;127m"
+  ListPrediction          = "$esc[38;2;124;120;140m"
+  ListPredictionTooltip   = "$esc[38;2;124;120;140m"
+  Member                  = "$esc[38;2;135;206;235m"
+  Number                  = "$esc[38;2;255;150;51m"
+  Operator                = "$esc[38;2;205;198;115m"
+  Parameter               = "$esc[38;2;127;207;120m"
+  String                  = "$esc[38;2;255;160;160m"
+  Type                    = "$esc[38;2;124;205;181m"
+  Variable                = "$esc[38;2;203;158;255m"
+  ListPredictionSelected  = "$esc[48;2;67;63;56m" + "$esc[38;2;245;245;220m"
+  Selection               = "$esc[48;2;67;63;56m" + "$esc[38;2;245;245;220m"
+}

--- a/extras/psreadline/themes/dark/oasis_midnight_dark.ps1
+++ b/extras/psreadline/themes/dark/oasis_midnight_dark.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/dark/oasis_midnight_dark.ps1
+## name: Oasis Midnight Dark
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;233;192;165m"
+  Comment                 = "$esc[38;2;105;128;157m"
+  ContinuationPrompt      = "$esc[38;2;78;101;120m"
+  Default                 = "$esc[38;2;245;245;220m"
+  Emphasis                = "$esc[38;2;127;207;120m"
+  Error                   = "$esc[38;2;255;160;160m"
+  InlinePrediction        = "$esc[38;2;111;122;131m"
+  Keyword                 = "$esc[38;2;216;207;127m"
+  ListPrediction          = "$esc[38;2;111;122;131m"
+  ListPredictionTooltip   = "$esc[38;2;111;122;131m"
+  Member                  = "$esc[38;2;135;206;235m"
+  Number                  = "$esc[38;2;255;163;77m"
+  Operator                = "$esc[38;2;205;198;115m"
+  Parameter               = "$esc[38;2;127;207;120m"
+  String                  = "$esc[38;2;255;160;160m"
+  Type                    = "$esc[38;2;124;205;181m"
+  Variable                = "$esc[38;2;194;142;255m"
+  ListPredictionSelected  = "$esc[48;2;30;42;56m" + "$esc[38;2;245;245;220m"
+  Selection               = "$esc[48;2;30;42;56m" + "$esc[38;2;245;245;220m"
+}

--- a/extras/psreadline/themes/dark/oasis_mirage_dark.ps1
+++ b/extras/psreadline/themes/dark/oasis_mirage_dark.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/dark/oasis_mirage_dark.ps1
+## name: Oasis Mirage Dark
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;233;192;165m"
+  Comment                 = "$esc[38;2;67;151;137m"
+  ContinuationPrompt      = "$esc[38;2;88;114;112m"
+  Default                 = "$esc[38;2;245;245;220m"
+  Emphasis                = "$esc[38;2;210;173;255m"
+  Error                   = "$esc[38;2;255;160;160m"
+  InlinePrediction        = "$esc[38;2;115;130;129m"
+  Keyword                 = "$esc[38;2;138;211;190m"
+  ListPrediction          = "$esc[38;2;115;130;129m"
+  ListPredictionTooltip   = "$esc[38;2;115;130;129m"
+  Member                  = "$esc[38;2;135;206;235m"
+  Number                  = "$esc[38;2;255;163;77m"
+  Operator                = "$esc[38;2;124;205;181m"
+  Parameter               = "$esc[38;2;127;207;120m"
+  String                  = "$esc[38;2;255;160;160m"
+  Type                    = "$esc[38;2;243;234;159m"
+  Variable                = "$esc[38;2;194;142;255m"
+  ListPredictionSelected  = "$esc[48;2;33;51;59m" + "$esc[38;2;245;245;220m"
+  Selection               = "$esc[48;2;33;51;59m" + "$esc[38;2;245;245;220m"
+}

--- a/extras/psreadline/themes/dark/oasis_moonlight_dark.ps1
+++ b/extras/psreadline/themes/dark/oasis_moonlight_dark.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/dark/oasis_moonlight_dark.ps1
+## name: Oasis Moonlight Dark
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;233;192;165m"
+  Comment                 = "$esc[38;2;105;128;157m"
+  ContinuationPrompt      = "$esc[38;2;78;101;120m"
+  Default                 = "$esc[38;2;245;245;220m"
+  Emphasis                = "$esc[38;2;255;160;160m"
+  Error                   = "$esc[38;2;255;160;160m"
+  InlinePrediction        = "$esc[38;2;113;122;132m"
+  Keyword                 = "$esc[38;2;216;207;127m"
+  ListPrediction          = "$esc[38;2;113;122;132m"
+  ListPredictionTooltip   = "$esc[38;2;113;122;132m"
+  Member                  = "$esc[38;2;135;206;235m"
+  Number                  = "$esc[38;2;255;150;51m"
+  Operator                = "$esc[38;2;205;198;115m"
+  Parameter               = "$esc[38;2;127;207;120m"
+  String                  = "$esc[38;2;255;160;160m"
+  Type                    = "$esc[38;2;124;205;181m"
+  Variable                = "$esc[38;2;194;142;255m"
+  ListPredictionSelected  = "$esc[48;2;36;54;77m" + "$esc[38;2;245;245;220m"
+  Selection               = "$esc[48;2;36;54;77m" + "$esc[38;2;245;245;220m"
+}

--- a/extras/psreadline/themes/dark/oasis_night_dark.ps1
+++ b/extras/psreadline/themes/dark/oasis_night_dark.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/dark/oasis_night_dark.ps1
+## name: Oasis Night Dark
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;233;192;165m"
+  Comment                 = "$esc[38;2;112;140;168m"
+  ContinuationPrompt      = "$esc[38;2;83;107;131m"
+  Default                 = "$esc[38;2;245;245;220m"
+  Emphasis                = "$esc[38;2;255;160;160m"
+  Error                   = "$esc[38;2;255;160;160m"
+  InlinePrediction        = "$esc[38;2;114;123;133m"
+  Keyword                 = "$esc[38;2;216;207;127m"
+  ListPrediction          = "$esc[38;2;114;123;133m"
+  ListPredictionTooltip   = "$esc[38;2;114;123;133m"
+  Member                  = "$esc[38;2;135;206;235m"
+  Number                  = "$esc[38;2;255;150;51m"
+  Operator                = "$esc[38;2;205;198;115m"
+  Parameter               = "$esc[38;2;127;207;120m"
+  String                  = "$esc[38;2;255;160;160m"
+  Type                    = "$esc[38;2;124;205;181m"
+  Variable                = "$esc[38;2;194;142;255m"
+  ListPredictionSelected  = "$esc[48;2;36;54;77m" + "$esc[38;2;245;245;220m"
+  Selection               = "$esc[48;2;36;54;77m" + "$esc[38;2;245;245;220m"
+}

--- a/extras/psreadline/themes/dark/oasis_rose_dark.ps1
+++ b/extras/psreadline/themes/dark/oasis_rose_dark.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/dark/oasis_rose_dark.ps1
+## name: Oasis Rose Dark
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;233;192;165m"
+  Comment                 = "$esc[38;2;168;122;145m"
+  ContinuationPrompt      = "$esc[38;2;129;97;117m"
+  Default                 = "$esc[38;2;245;245;220m"
+  Emphasis                = "$esc[38;2;124;205;181m"
+  Error                   = "$esc[38;2;255;160;160m"
+  InlinePrediction        = "$esc[38;2;140;125;134m"
+  Keyword                 = "$esc[38;2;236;181;203m"
+  ListPrediction          = "$esc[38;2;140;125;134m"
+  ListPredictionTooltip   = "$esc[38;2;140;125;134m"
+  Member                  = "$esc[38;2;135;206;235m"
+  Number                  = "$esc[38;2;255;150;51m"
+  Operator                = "$esc[38;2;223;147;177m"
+  Parameter               = "$esc[38;2;127;207;120m"
+  String                  = "$esc[38;2;255;160;160m"
+  Type                    = "$esc[38;2;124;205;181m"
+  Variable                = "$esc[38;2;203;158;255m"
+  ListPredictionSelected  = "$esc[48;2;78;55;71m" + "$esc[38;2;245;245;220m"
+  Selection               = "$esc[48;2;78;55;71m" + "$esc[38;2;245;245;220m"
+}

--- a/extras/psreadline/themes/dark/oasis_scorpion_dark.ps1
+++ b/extras/psreadline/themes/dark/oasis_scorpion_dark.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/dark/oasis_scorpion_dark.ps1
+## name: Oasis Scorpion Dark
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;233;192;165m"
+  Comment                 = "$esc[38;2;176;138;128m"
+  ContinuationPrompt      = "$esc[38;2;154;111;102m"
+  Default                 = "$esc[38;2;245;245;220m"
+  Emphasis                = "$esc[38;2;216;207;127m"
+  Error                   = "$esc[38;2;255;160;160m"
+  InlinePrediction        = "$esc[38;2;131;117;112m"
+  Keyword                 = "$esc[38;2;216;207;127m"
+  ListPrediction          = "$esc[38;2;131;117;112m"
+  ListPredictionTooltip   = "$esc[38;2;131;117;112m"
+  Member                  = "$esc[38;2;135;206;235m"
+  Number                  = "$esc[38;2;255;163;77m"
+  Operator                = "$esc[38;2;205;198;115m"
+  Parameter               = "$esc[38;2;127;207;120m"
+  String                  = "$esc[38;2;255;160;160m"
+  Type                    = "$esc[38;2;124;205;181m"
+  Variable                = "$esc[38;2;194;142;255m"
+  ListPredictionSelected  = "$esc[48;2;90;56;36m" + "$esc[38;2;245;245;220m"
+  Selection               = "$esc[48;2;90;56;36m" + "$esc[38;2;245;245;220m"
+}

--- a/extras/psreadline/themes/dark/oasis_sol_dark.ps1
+++ b/extras/psreadline/themes/dark/oasis_sol_dark.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/dark/oasis_sol_dark.ps1
+## name: Oasis Sol Dark
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;233;192;165m"
+  Comment                 = "$esc[38;2;162;125;120m"
+  ContinuationPrompt      = "$esc[38;2;131;97;91m"
+  Default                 = "$esc[38;2;245;245;220m"
+  Emphasis                = "$esc[38;2;127;207;120m"
+  Error                   = "$esc[38;2;255;160;160m"
+  InlinePrediction        = "$esc[38;2;126;126;126m"
+  Keyword                 = "$esc[38;2;243;148;147m"
+  ListPrediction          = "$esc[38;2;126;126;126m"
+  ListPredictionTooltip   = "$esc[38;2;126;126;126m"
+  Member                  = "$esc[38;2;135;206;235m"
+  Number                  = "$esc[38;2;255;150;51m"
+  Operator                = "$esc[38;2;245;139;139m"
+  Parameter               = "$esc[38;2;127;207;120m"
+  String                  = "$esc[38;2;216;207;127m"
+  Type                    = "$esc[38;2;124;205;181m"
+  Variable                = "$esc[38;2;203;158;255m"
+  ListPredictionSelected  = "$esc[48;2;67;40;35m" + "$esc[38;2;245;245;220m"
+  Selection               = "$esc[48;2;67;40;35m" + "$esc[38;2;245;245;220m"
+}

--- a/extras/psreadline/themes/dark/oasis_starlight_dark.ps1
+++ b/extras/psreadline/themes/dark/oasis_starlight_dark.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/dark/oasis_starlight_dark.ps1
+## name: Oasis Starlight Dark
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;233;192;165m"
+  Comment                 = "$esc[38;2;94;124;154m"
+  ContinuationPrompt      = "$esc[38;2;79;91;107m"
+  Default                 = "$esc[38;2;245;245;220m"
+  Emphasis                = "$esc[38;2;255;160;160m"
+  Error                   = "$esc[38;2;255;160;160m"
+  InlinePrediction        = "$esc[38;2;110;125;129m"
+  Keyword                 = "$esc[38;2;216;207;127m"
+  ListPrediction          = "$esc[38;2;110;125;129m"
+  ListPredictionTooltip   = "$esc[38;2;110;125;129m"
+  Member                  = "$esc[38;2;135;206;235m"
+  Number                  = "$esc[38;2;255;150;51m"
+  Operator                = "$esc[38;2;205;198;115m"
+  Parameter               = "$esc[38;2;127;207;120m"
+  String                  = "$esc[38;2;255;144;144m"
+  Type                    = "$esc[38;2;124;205;181m"
+  Variable                = "$esc[38;2;168;112;240m"
+  ListPredictionSelected  = "$esc[48;2;77;69;40m" + "$esc[38;2;245;245;220m"
+  Selection               = "$esc[48;2;77;69;40m" + "$esc[38;2;245;245;220m"
+}

--- a/extras/psreadline/themes/dark/oasis_twilight_dark.ps1
+++ b/extras/psreadline/themes/dark/oasis_twilight_dark.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/dark/oasis_twilight_dark.ps1
+## name: Oasis Twilight Dark
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;240;230;140m"
+  Comment                 = "$esc[38;2;139;128;170m"
+  ContinuationPrompt      = "$esc[38;2;113;96;154m"
+  Default                 = "$esc[38;2;245;245;220m"
+  Emphasis                = "$esc[38;2;240;230;140m"
+  Error                   = "$esc[38;2;255;160;160m"
+  InlinePrediction        = "$esc[38;2;127;122;141m"
+  Keyword                 = "$esc[38;2;249;175;150m"
+  ListPrediction          = "$esc[38;2;127;122;141m"
+  ListPredictionTooltip   = "$esc[38;2;127;122;141m"
+  Member                  = "$esc[38;2;146;211;237m"
+  Number                  = "$esc[38;2;255;163;77m"
+  Operator                = "$esc[38;2;249;175;150m"
+  Parameter               = "$esc[38;2;127;207;120m"
+  String                  = "$esc[38;2;255;160;160m"
+  Type                    = "$esc[38;2;124;205;181m"
+  Variable                = "$esc[38;2;203;158;255m"
+  ListPredictionSelected  = "$esc[48;2;54;35;67m" + "$esc[38;2;245;245;220m"
+  Selection               = "$esc[48;2;54;35;67m" + "$esc[38;2;245;245;220m"
+}

--- a/extras/psreadline/themes/light/1/oasis_abyss_light_1.ps1
+++ b/extras/psreadline/themes/light/1/oasis_abyss_light_1.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/1/oasis_abyss_light_1.ps1
+## name: Oasis Abyss Light 1
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;104;67;45m"
+  Comment                 = "$esc[38;2;107;104;93m"
+  ContinuationPrompt      = "$esc[38;2;106;104;95m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;56;128;50m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;134;133;127m"
+  Keyword                 = "$esc[38;2;110;100;44m"
+  ListPrediction          = "$esc[38;2;134;133;127m"
+  ListPredictionTooltip   = "$esc[38;2;134;133;127m"
+  Member                  = "$esc[38;2;38;100;125m"
+  Number                  = "$esc[38;2;155;80;17m"
+  Operator                = "$esc[38;2;94;89;42m"
+  Parameter               = "$esc[38;2;54;104;50m"
+  String                  = "$esc[38;2;152;17;22m"
+  Type                    = "$esc[38;2;51;103;88m"
+  Variable                = "$esc[38;2;122;29;210m"
+  ListPredictionSelected  = "$esc[48;2;200;200;200m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;200;200;200m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/1/oasis_cactus_light_1.ps1
+++ b/extras/psreadline/themes/light/1/oasis_cactus_light_1.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/1/oasis_cactus_light_1.ps1
+## name: Oasis Cactus Light 1
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;117;75;50m"
+  Comment                 = "$esc[38;2;96;120;99m"
+  ContinuationPrompt      = "$esc[38;2;105;117;107m"
+  Default                 = "$esc[38;2;28;28;19m"
+  Emphasis                = "$esc[38;2;171;7;7m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;138;145;140m"
+  Keyword                 = "$esc[38;2;70;121;73m"
+  ListPrediction          = "$esc[38;2;138;145;140m"
+  ListPredictionTooltip   = "$esc[38;2;138;145;140m"
+  Member                  = "$esc[38;2;42;110;137m"
+  Number                  = "$esc[38;2;170;87;19m"
+  Operator                = "$esc[38;2;62;107;64m"
+  Parameter               = "$esc[38;2;133;96;19m"
+  String                  = "$esc[38;2;170;19;24m"
+  Type                    = "$esc[38;2;56;113;96m"
+  Variable                = "$esc[38;2;134;39;225m"
+  ListPredictionSelected  = "$esc[48;2;198;231;210m" + "$esc[38;2;28;28;19m"
+  Selection               = "$esc[48;2;198;231;210m" + "$esc[38;2;28;28;19m"
+}

--- a/extras/psreadline/themes/light/1/oasis_canyon_light_1.ps1
+++ b/extras/psreadline/themes/light/1/oasis_canyon_light_1.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/1/oasis_canyon_light_1.ps1
+## name: Oasis Canyon Light 1
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;82;75;28m"
+  Comment                 = "$esc[38;2;130;96;80m"
+  ContinuationPrompt      = "$esc[38;2;120;99;89m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;171;7;7m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;136;131;127m"
+  Keyword                 = "$esc[38;2;174;61;29m"
+  ListPrediction          = "$esc[38;2;136;131;127m"
+  ListPredictionTooltip   = "$esc[38;2;136;131;127m"
+  Member                  = "$esc[38;2;38;99;124m"
+  Number                  = "$esc[38;2;154;79;17m"
+  Operator                = "$esc[38;2;153;54;26m"
+  Parameter               = "$esc[38;2;53;104;50m"
+  String                  = "$esc[38;2;151;16;22m"
+  Type                    = "$esc[38;2;50;102;87m"
+  Variable                = "$esc[38;2;121;29;208m"
+  ListPredictionSelected  = "$esc[48;2;231;195;165m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;231;195;165m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/1/oasis_desert_light_1.ps1
+++ b/extras/psreadline/themes/light/1/oasis_desert_light_1.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/1/oasis_desert_light_1.ps1
+## name: Oasis Desert Light 1
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;116;74;50m"
+  Comment                 = "$esc[38;2;116;113;101m"
+  ContinuationPrompt      = "$esc[38;2;115;113;103m"
+  Default                 = "$esc[38;2;27;27;19m"
+  Emphasis                = "$esc[38;2;56;128;50m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;144;143;137m"
+  Keyword                 = "$esc[38;2;122;109;28m"
+  ListPrediction          = "$esc[38;2;144;143;137m"
+  ListPredictionTooltip   = "$esc[38;2;144;143;137m"
+  Member                  = "$esc[38;2;41;109;136m"
+  Number                  = "$esc[38;2;169;87;18m"
+  Operator                = "$esc[38;2;106;97;42m"
+  Parameter               = "$esc[38;2;59;114;55m"
+  String                  = "$esc[38;2;168;18;24m"
+  Type                    = "$esc[38;2;55;112;96m"
+  Variable                = "$esc[38;2;133;37;224m"
+  ListPredictionSelected  = "$esc[48;2;237;228;182m" + "$esc[38;2;27;27;19m"
+  Selection               = "$esc[48;2;237;228;182m" + "$esc[38;2;27;27;19m"
+}

--- a/extras/psreadline/themes/light/1/oasis_dune_light_1.ps1
+++ b/extras/psreadline/themes/light/1/oasis_dune_light_1.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/1/oasis_dune_light_1.ps1
+## name: Oasis Dune Light 1
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;116;75;50m"
+  Comment                 = "$esc[38;2;125;111;102m"
+  ContinuationPrompt      = "$esc[38;2;122;112;102m"
+  Default                 = "$esc[38;2;28;28;19m"
+  Emphasis                = "$esc[38;2;54;124;105m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;148;143;139m"
+  Keyword                 = "$esc[38;2;122;110;29m"
+  ListPrediction          = "$esc[38;2;148;143;139m"
+  ListPredictionTooltip   = "$esc[38;2;148;143;139m"
+  Member                  = "$esc[38;2;42;110;137m"
+  Number                  = "$esc[38;2;170;87;19m"
+  Operator                = "$esc[38;2;106;97;42m"
+  Parameter               = "$esc[38;2;59;115;55m"
+  String                  = "$esc[38;2;169;18;24m"
+  Type                    = "$esc[38;2;56;113;96m"
+  Variable                = "$esc[38;2;134;38;225m"
+  ListPredictionSelected  = "$esc[48;2;243;218;186m" + "$esc[38;2;28;28;19m"
+  Selection               = "$esc[48;2;243;218;186m" + "$esc[38;2;28;28;19m"
+}

--- a/extras/psreadline/themes/light/1/oasis_lagoon_light_1.ps1
+++ b/extras/psreadline/themes/light/1/oasis_lagoon_light_1.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/1/oasis_lagoon_light_1.ps1
+## name: Oasis Lagoon Light 1
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;116;74;50m"
+  Comment                 = "$esc[38;2;85;117;139m"
+  ContinuationPrompt      = "$esc[38;2;96;117;129m"
+  Default                 = "$esc[38;2;27;27;19m"
+  Emphasis                = "$esc[38;2;171;7;7m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;139;144;147m"
+  Keyword                 = "$esc[38;2;23;107;209m"
+  ListPrediction          = "$esc[38;2;139;144;147m"
+  ListPredictionTooltip   = "$esc[38;2;139;144;147m"
+  Member                  = "$esc[38;2;40;110;136m"
+  Number                  = "$esc[38;2;170;87;19m"
+  Operator                = "$esc[38;2;20;95;185m"
+  Parameter               = "$esc[38;2;59;115;55m"
+  String                  = "$esc[38;2;169;18;24m"
+  Type                    = "$esc[38;2;114;103;30m"
+  Variable                = "$esc[38;2;134;38;225m"
+  ListPredictionSelected  = "$esc[48;2;189;214;245m" + "$esc[38;2;27;27;19m"
+  Selection               = "$esc[48;2;189;214;245m" + "$esc[38;2;27;27;19m"
+}

--- a/extras/psreadline/themes/light/1/oasis_luna_light_1.ps1
+++ b/extras/psreadline/themes/light/1/oasis_luna_light_1.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/1/oasis_luna_light_1.ps1
+## name: Oasis Luna Light 1
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;114;73;49m"
+  Comment                 = "$esc[38;2;117;105;154m"
+  ContinuationPrompt      = "$esc[38;2;113;109;129m"
+  Default                 = "$esc[38;2;25;25;17m"
+  Emphasis                = "$esc[38;2;27;123;152m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;141;140;149m"
+  Keyword                 = "$esc[38;2;118;108;47m"
+  ListPrediction          = "$esc[38;2;141;140;149m"
+  ListPredictionTooltip   = "$esc[38;2;141;140;149m"
+  Member                  = "$esc[38;2;41;108;135m"
+  Number                  = "$esc[38;2;167;85;18m"
+  Operator                = "$esc[38;2;102;96;46m"
+  Parameter               = "$esc[38;2;58;113;54m"
+  String                  = "$esc[38;2;166;18;24m"
+  Type                    = "$esc[38;2;55;111;95m"
+  Variable                = "$esc[38;2;131;34;224m"
+  ListPredictionSelected  = "$esc[48;2;194;194;240m" + "$esc[38;2;25;25;17m"
+  Selection               = "$esc[48;2;194;194;240m" + "$esc[38;2;25;25;17m"
+}

--- a/extras/psreadline/themes/light/1/oasis_midnight_light_1.ps1
+++ b/extras/psreadline/themes/light/1/oasis_midnight_light_1.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/1/oasis_midnight_light_1.ps1
+## name: Oasis Midnight Light 1
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;110;71;47m"
+  Comment                 = "$esc[38;2;98;110;129m"
+  ContinuationPrompt      = "$esc[38;2;100;110;119m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;56;128;50m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;133;139;143m"
+  Keyword                 = "$esc[38;2;115;105;46m"
+  ListPrediction          = "$esc[38;2;133;139;143m"
+  ListPredictionTooltip   = "$esc[38;2;133;139;143m"
+  Member                  = "$esc[38;2;40;105;131m"
+  Number                  = "$esc[38;2;162;83;18m"
+  Operator                = "$esc[38;2;99;93;45m"
+  Parameter               = "$esc[38;2;56;110;52m"
+  String                  = "$esc[38;2;160;18;23m"
+  Type                    = "$esc[38;2;53;108;92m"
+  Variable                = "$esc[38;2;128;31;220m"
+  ListPredictionSelected  = "$esc[48;2;197;206;222m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;197;206;222m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/1/oasis_mirage_light_1.ps1
+++ b/extras/psreadline/themes/light/1/oasis_mirage_light_1.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/1/oasis_mirage_light_1.ps1
+## name: Oasis Mirage Light 1
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;117;75;50m"
+  Comment                 = "$esc[38;2;75;123;115m"
+  ContinuationPrompt      = "$esc[38;2;103;117;116m"
+  Default                 = "$esc[38;2;28;28;20m"
+  Emphasis                = "$esc[38;2;81;7;171m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;139;145;145m"
+  Keyword                 = "$esc[38;2;56;121;104m"
+  ListPrediction          = "$esc[38;2;139;145;145m"
+  ListPredictionTooltip   = "$esc[38;2;139;145;145m"
+  Member                  = "$esc[38;2;42;111;138m"
+  Number                  = "$esc[38;2;170;87;19m"
+  Operator                = "$esc[38;2;51;107;90m"
+  Parameter               = "$esc[38;2;59;115;55m"
+  String                  = "$esc[38;2;170;19;24m"
+  Type                    = "$esc[38;2;115;104;30m"
+  Variable                = "$esc[38;2;134;39;225m"
+  ListPredictionSelected  = "$esc[48;2;192;235;228m" + "$esc[38;2;28;28;20m"
+  Selection               = "$esc[48;2;192;235;228m" + "$esc[38;2;28;28;20m"
+}

--- a/extras/psreadline/themes/light/1/oasis_moonlight_light_1.ps1
+++ b/extras/psreadline/themes/light/1/oasis_moonlight_light_1.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/1/oasis_moonlight_light_1.ps1
+## name: Oasis Moonlight Light 1
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;113;72;49m"
+  Comment                 = "$esc[38;2;100;111;131m"
+  ContinuationPrompt      = "$esc[38;2;102;112;120m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;171;7;7m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;136;140;145m"
+  Keyword                 = "$esc[38;2;117;107;47m"
+  ListPrediction          = "$esc[38;2;136;140;145m"
+  ListPredictionTooltip   = "$esc[38;2;136;140;145m"
+  Member                  = "$esc[38;2;41;107;133m"
+  Number                  = "$esc[38;2;165;85;18m"
+  Operator                = "$esc[38;2;101;95;45m"
+  Parameter               = "$esc[38;2;57;112;53m"
+  String                  = "$esc[38;2;164;18;23m"
+  Type                    = "$esc[38;2;54;110;94m"
+  Variable                = "$esc[38;2;130;32;224m"
+  ListPredictionSelected  = "$esc[48;2;220;217;197m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;220;217;197m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/1/oasis_night_light_1.ps1
+++ b/extras/psreadline/themes/light/1/oasis_night_light_1.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/1/oasis_night_light_1.ps1
+## name: Oasis Night Light 1
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;115;74;49m"
+  Comment                 = "$esc[38;2;98;114;135m"
+  ContinuationPrompt      = "$esc[38;2;104;114;123m"
+  Default                 = "$esc[38;2;26;26;18m"
+  Emphasis                = "$esc[38;2;171;7;7m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;138;143;147m"
+  Keyword                 = "$esc[38;2;119;109;47m"
+  ListPrediction          = "$esc[38;2;138;143;147m"
+  ListPredictionTooltip   = "$esc[38;2;138;143;147m"
+  Member                  = "$esc[38;2;41;109;136m"
+  Number                  = "$esc[38;2;168;86;18m"
+  Operator                = "$esc[38;2;102;97;46m"
+  Parameter               = "$esc[38;2;58;114;54m"
+  String                  = "$esc[38;2;167;18;24m"
+  Type                    = "$esc[38;2;55;111;95m"
+  Variable                = "$esc[38;2;132;36;224m"
+  ListPredictionSelected  = "$esc[48;2;206;214;222m" + "$esc[38;2;26;26;18m"
+  Selection               = "$esc[48;2;206;214;222m" + "$esc[38;2;26;26;18m"
+}

--- a/extras/psreadline/themes/light/1/oasis_rose_light_1.ps1
+++ b/extras/psreadline/themes/light/1/oasis_rose_light_1.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/1/oasis_rose_light_1.ps1
+## name: Oasis Rose Light 1
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;112;72;48m"
+  Comment                 = "$esc[38;2;133;102;116m"
+  ContinuationPrompt      = "$esc[38;2;122;106;116m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;53;126;104m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;144;138;142m"
+  Keyword                 = "$esc[38;2;179;64;110m"
+  ListPrediction          = "$esc[38;2;144;138;142m"
+  ListPredictionTooltip   = "$esc[38;2;144;138;142m"
+  Member                  = "$esc[38;2;40;107;133m"
+  Number                  = "$esc[38;2;164;84;18m"
+  Operator                = "$esc[38;2;153;61;97m"
+  Parameter               = "$esc[38;2;57;111;53m"
+  String                  = "$esc[38;2;163;18;23m"
+  Type                    = "$esc[38;2;54;109;93m"
+  Variable                = "$esc[38;2;130;31;223m"
+  ListPredictionSelected  = "$esc[48;2;236;191;217m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;236;191;217m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/1/oasis_scorpion_light_1.ps1
+++ b/extras/psreadline/themes/light/1/oasis_scorpion_light_1.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/1/oasis_scorpion_light_1.ps1
+## name: Oasis Scorpion Light 1
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;105;67;45m"
+  Comment                 = "$esc[38;2;126;98;94m"
+  ContinuationPrompt      = "$esc[38;2;117;102;99m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;133;124;45m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;139;132;130m"
+  Keyword                 = "$esc[38;2;111;101;44m"
+  ListPrediction          = "$esc[38;2;139;132;130m"
+  ListPredictionTooltip   = "$esc[38;2;139;132;130m"
+  Member                  = "$esc[38;2;38;101;126m"
+  Number                  = "$esc[38;2;156;80;17m"
+  Operator                = "$esc[38;2;95;89;43m"
+  Parameter               = "$esc[38;2;54;105;50m"
+  String                  = "$esc[38;2;153;17;22m"
+  Type                    = "$esc[38;2;51;103;88m"
+  Variable                = "$esc[38;2;123;30;211m"
+  ListPredictionSelected  = "$esc[48;2;240;187;169m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;240;187;169m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/1/oasis_sol_light_1.ps1
+++ b/extras/psreadline/themes/light/1/oasis_sol_light_1.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/1/oasis_sol_light_1.ps1
+## name: Oasis Sol Light 1
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;101;65;44m"
+  Comment                 = "$esc[38;2;120;96;94m"
+  ContinuationPrompt      = "$esc[38;2;115;98;95m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;56;128;50m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;130;130;130m"
+  Keyword                 = "$esc[38;2;185;41;44m"
+  ListPrediction          = "$esc[38;2;130;130;130m"
+  ListPredictionTooltip   = "$esc[38;2;130;130;130m"
+  Member                  = "$esc[38;2;37;98;122m"
+  Number                  = "$esc[38;2;151;78;17m"
+  Operator                = "$esc[38;2;164;33;37m"
+  Parameter               = "$esc[38;2;52;102;49m"
+  String                  = "$esc[38;2;80;74;32m"
+  Type                    = "$esc[38;2;50;100;85m"
+  Variable                = "$esc[38;2;119;29;204m"
+  ListPredictionSelected  = "$esc[48;2;238;170;170m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;238;170;170m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/1/oasis_starlight_light_1.ps1
+++ b/extras/psreadline/themes/light/1/oasis_starlight_light_1.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/1/oasis_starlight_light_1.ps1
+## name: Oasis Starlight Light 1
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;118;76;51m"
+  Comment                 = "$esc[38;2;100;117;138m"
+  ContinuationPrompt      = "$esc[38;2;108;116;126m"
+  Default                 = "$esc[38;2;30;30;20m"
+  Emphasis                = "$esc[38;2;171;7;7m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;140;146;148m"
+  Keyword                 = "$esc[38;2;121;111;49m"
+  ListPrediction          = "$esc[38;2;140;146;148m"
+  ListPredictionTooltip   = "$esc[38;2;140;146;148m"
+  Member                  = "$esc[38;2;42;111;139m"
+  Number                  = "$esc[38;2;172;88;19m"
+  Operator                = "$esc[38;2;105;99;47m"
+  Parameter               = "$esc[38;2;60;116;56m"
+  String                  = "$esc[38;2;172;19;25m"
+  Type                    = "$esc[38;2;56;114;97m"
+  Variable                = "$esc[38;2;130;58;207m"
+  ListPredictionSelected  = "$esc[48;2;230;225;204m" + "$esc[38;2;30;30;20m"
+  Selection               = "$esc[48;2;230;225;204m" + "$esc[38;2;30;30;20m"
+}

--- a/extras/psreadline/themes/light/1/oasis_twilight_light_1.ps1
+++ b/extras/psreadline/themes/light/1/oasis_twilight_light_1.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/1/oasis_twilight_light_1.ps1
+## name: Oasis Twilight Light 1
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;92;84;31m"
+  Comment                 = "$esc[38;2;118;108;141m"
+  ContinuationPrompt      = "$esc[38;2;116;110;130m"
+  Default                 = "$esc[38;2;27;27;19m"
+  Emphasis                = "$esc[38;2;152;140;26m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;143;141;149m"
+  Keyword                 = "$esc[38;2;190;67;32m"
+  ListPrediction          = "$esc[38;2;143;141;149m"
+  ListPredictionTooltip   = "$esc[38;2;143;141;149m"
+  Member                  = "$esc[38;2;41;109;136m"
+  Number                  = "$esc[38;2;168;86;18m"
+  Operator                = "$esc[38;2;169;59;28m"
+  Parameter               = "$esc[38;2;59;114;54m"
+  String                  = "$esc[38;2;168;18;24m"
+  Type                    = "$esc[38;2;55;112;96m"
+  Variable                = "$esc[38;2;133;36;224m"
+  ListPredictionSelected  = "$esc[48;2;219;199;235m" + "$esc[38;2;27;27;19m"
+  Selection               = "$esc[48;2;219;199;235m" + "$esc[38;2;27;27;19m"
+}

--- a/extras/psreadline/themes/light/2/oasis_abyss_light_2.ps1
+++ b/extras/psreadline/themes/light/2/oasis_abyss_light_2.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/2/oasis_abyss_light_2.ps1
+## name: Oasis Abyss Light 2
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;98;63;43m"
+  Comment                 = "$esc[38;2;103;100;90m"
+  ContinuationPrompt      = "$esc[38;2;102;100;92m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;53;122;47m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;130;128;122m"
+  Keyword                 = "$esc[38;2;105;96;42m"
+  ListPrediction          = "$esc[38;2;130;128;122m"
+  ListPredictionTooltip   = "$esc[38;2;130;128;122m"
+  Member                  = "$esc[38;2;37;96;119m"
+  Number                  = "$esc[38;2;149;76;16m"
+  Operator                = "$esc[38;2;90;84;41m"
+  Parameter               = "$esc[38;2;52;100;47m"
+  String                  = "$esc[38;2;144;16;21m"
+  Type                    = "$esc[38;2;49;98;84m"
+  Variable                = "$esc[38;2;116;28;200m"
+  ListPredictionSelected  = "$esc[48;2;193;193;193m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;193;193;193m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/2/oasis_cactus_light_2.ps1
+++ b/extras/psreadline/themes/light/2/oasis_cactus_light_2.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/2/oasis_cactus_light_2.ps1
+## name: Oasis Cactus Light 2
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;112;72;49m"
+  Comment                 = "$esc[38;2;92;116;94m"
+  ContinuationPrompt      = "$esc[38;2;100;113;103m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;163;5;5m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;134;141;135m"
+  Keyword                 = "$esc[38;2;68;116;71m"
+  ListPrediction          = "$esc[38;2;134;141;135m"
+  ListPredictionTooltip   = "$esc[38;2;134;141;135m"
+  Member                  = "$esc[38;2;41;106;132m"
+  Number                  = "$esc[38;2;164;84;18m"
+  Operator                = "$esc[38;2;59;103;61m"
+  Parameter               = "$esc[38;2;128;93;18m"
+  String                  = "$esc[38;2;163;18;24m"
+  Type                    = "$esc[38;2;54;109;93m"
+  Variable                = "$esc[38;2;129;32;222m"
+  ListPredictionSelected  = "$esc[48;2;189;225;200m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;189;225;200m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/2/oasis_canyon_light_2.ps1
+++ b/extras/psreadline/themes/light/2/oasis_canyon_light_2.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/2/oasis_canyon_light_2.ps1
+## name: Oasis Canyon Light 2
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;78;71;26m"
+  Comment                 = "$esc[38;2;125;91;76m"
+  ContinuationPrompt      = "$esc[38;2;114;95;85m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;163;5;5m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;133;126;122m"
+  Keyword                 = "$esc[38;2;167;59;29m"
+  ListPrediction          = "$esc[38;2;133;126;122m"
+  ListPredictionTooltip   = "$esc[38;2;133;126;122m"
+  Member                  = "$esc[38;2;36;95;118m"
+  Number                  = "$esc[38;2;148;75;16m"
+  Operator                = "$esc[38;2;146;51;25m"
+  Parameter               = "$esc[38;2;51;99;47m"
+  String                  = "$esc[38;2;143;16;21m"
+  Type                    = "$esc[38;2;49;97;83m"
+  Variable                = "$esc[38;2;115;28;198m"
+  ListPredictionSelected  = "$esc[48;2;228;187;152m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;228;187;152m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/2/oasis_desert_light_2.ps1
+++ b/extras/psreadline/themes/light/2/oasis_desert_light_2.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/2/oasis_desert_light_2.ps1
+## name: Oasis Desert Light 2
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;112;72;49m"
+  Comment                 = "$esc[38;2;114;111;99m"
+  ContinuationPrompt      = "$esc[38;2;113;111;102m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;53;122;47m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;141;140;133m"
+  Keyword                 = "$esc[38;2;119;107;29m"
+  ListPrediction          = "$esc[38;2;141;140;133m"
+  ListPredictionTooltip   = "$esc[38;2;141;140;133m"
+  Member                  = "$esc[38;2;41;107;133m"
+  Number                  = "$esc[38;2;165;84;18m"
+  Operator                = "$esc[38;2;103;94;41m"
+  Parameter               = "$esc[38;2;58;111;53m"
+  String                  = "$esc[38;2;163;18;24m"
+  Type                    = "$esc[38;2;55;109;93m"
+  Variable                = "$esc[38;2;130;32;223m"
+  ListPredictionSelected  = "$esc[48;2;234;224;170m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;234;224;170m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/2/oasis_dune_light_2.ps1
+++ b/extras/psreadline/themes/light/2/oasis_dune_light_2.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/2/oasis_dune_light_2.ps1
+## name: Oasis Dune Light 2
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;112;72;49m"
+  Comment                 = "$esc[38;2;121;108;98m"
+  ContinuationPrompt      = "$esc[38;2;119;108;99m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;50;118;99m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;144;139;134m"
+  Keyword                 = "$esc[38;2;118;106;29m"
+  ListPrediction          = "$esc[38;2;144;139;134m"
+  ListPredictionTooltip   = "$esc[38;2;144;139;134m"
+  Member                  = "$esc[38;2;41;106;132m"
+  Number                  = "$esc[38;2;165;84;18m"
+  Operator                = "$esc[38;2;102;94;41m"
+  Parameter               = "$esc[38;2;58;111;52m"
+  String                  = "$esc[38;2;163;18;24m"
+  Type                    = "$esc[38;2;55;109;93m"
+  Variable                = "$esc[38;2;129;32;222m"
+  ListPredictionSelected  = "$esc[48;2;239;215;174m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;239;215;174m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/2/oasis_lagoon_light_2.ps1
+++ b/extras/psreadline/themes/light/2/oasis_lagoon_light_2.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/2/oasis_lagoon_light_2.ps1
+## name: Oasis Lagoon Light 2
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;112;72;49m"
+  Comment                 = "$esc[38;2;82;114;134m"
+  ContinuationPrompt      = "$esc[38;2;92;113;126m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;163;5;5m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;134;140;144m"
+  Keyword                 = "$esc[38;2;22;104;204m"
+  ListPrediction          = "$esc[38;2;134;140;144m"
+  ListPredictionTooltip   = "$esc[38;2;134;140;144m"
+  Member                  = "$esc[38;2;39;106;132m"
+  Number                  = "$esc[38;2;165;84;18m"
+  Operator                = "$esc[38;2;20;92;180m"
+  Parameter               = "$esc[38;2;58;111;52m"
+  String                  = "$esc[38;2;163;18;24m"
+  Type                    = "$esc[38;2;111;100;29m"
+  Variable                = "$esc[38;2;129;32;222m"
+  ListPredictionSelected  = "$esc[48;2;179;210;245m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;179;210;245m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/2/oasis_luna_light_2.ps1
+++ b/extras/psreadline/themes/light/2/oasis_luna_light_2.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/2/oasis_luna_light_2.ps1
+## name: Oasis Luna Light 2
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;109;70;48m"
+  Comment                 = "$esc[38;2;113;101;151m"
+  ContinuationPrompt      = "$esc[38;2;109;106;127m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;24;117;144m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;138;136;145m"
+  Keyword                 = "$esc[38;2;114;105;46m"
+  ListPrediction          = "$esc[38;2;138;136;145m"
+  ListPredictionTooltip   = "$esc[38;2;138;136;145m"
+  Member                  = "$esc[38;2;40;104;130m"
+  Number                  = "$esc[38;2;162;82;18m"
+  Operator                = "$esc[38;2;98;93;45m"
+  Parameter               = "$esc[38;2;56;109;51m"
+  String                  = "$esc[38;2;159;17;23m"
+  Type                    = "$esc[38;2;53;107;91m"
+  Variable                = "$esc[38;2;127;31;218m"
+  ListPredictionSelected  = "$esc[48;2;193;185;240m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;193;185;240m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/2/oasis_midnight_light_2.ps1
+++ b/extras/psreadline/themes/light/2/oasis_midnight_light_2.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/2/oasis_midnight_light_2.ps1
+## name: Oasis Midnight Light 2
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;103;66;45m"
+  Comment                 = "$esc[38;2;93;104;122m"
+  ContinuationPrompt      = "$esc[38;2;96;105;112m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;53;122;47m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;127;133;137m"
+  Keyword                 = "$esc[38;2;109;100;44m"
+  ListPrediction          = "$esc[38;2;127;133;137m"
+  ListPredictionTooltip   = "$esc[38;2;127;133;137m"
+  Member                  = "$esc[38;2;38;99;124m"
+  Number                  = "$esc[38;2;155;79;17m"
+  Operator                = "$esc[38;2;94;88;42m"
+  Parameter               = "$esc[38;2;54;104;49m"
+  String                  = "$esc[38;2;151;16;22m"
+  Type                    = "$esc[38;2;51;102;87m"
+  Variable                = "$esc[38;2;121;29;208m"
+  ListPredictionSelected  = "$esc[48;2;189;196;215m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;189;196;215m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/2/oasis_mirage_light_2.ps1
+++ b/extras/psreadline/themes/light/2/oasis_mirage_light_2.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/2/oasis_mirage_light_2.ps1
+## name: Oasis Mirage Light 2
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;113;72;49m"
+  Comment                 = "$esc[38;2;72;120;111m"
+  ContinuationPrompt      = "$esc[38;2;100;114;113m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;76;5;163m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;134;142;142m"
+  Keyword                 = "$esc[38;2;55;117;100m"
+  ListPrediction          = "$esc[38;2;134;142;142m"
+  ListPredictionTooltip   = "$esc[38;2;134;142;142m"
+  Member                  = "$esc[38;2;41;107;133m"
+  Number                  = "$esc[38;2;166;84;18m"
+  Operator                = "$esc[38;2;49;103;87m"
+  Parameter               = "$esc[38;2;58;112;53m"
+  String                  = "$esc[38;2;164;18;24m"
+  Type                    = "$esc[38;2;111;100;29m"
+  Variable                = "$esc[38;2;130;32;223m"
+  ListPredictionSelected  = "$esc[48;2;181;231;226m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;181;231;226m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/2/oasis_moonlight_light_2.ps1
+++ b/extras/psreadline/themes/light/2/oasis_moonlight_light_2.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/2/oasis_moonlight_light_2.ps1
+## name: Oasis Moonlight Light 2
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;107;69;47m"
+  Comment                 = "$esc[38;2;96;107;126m"
+  ContinuationPrompt      = "$esc[38;2;99;108;116m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;163;5;5m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;132;136;141m"
+  Keyword                 = "$esc[38;2;112;103;45m"
+  ListPrediction          = "$esc[38;2;132;136;141m"
+  ListPredictionTooltip   = "$esc[38;2;132;136;141m"
+  Member                  = "$esc[38;2;39;103;128m"
+  Number                  = "$esc[38;2;159;81;17m"
+  Operator                = "$esc[38;2;97;91;44m"
+  Parameter               = "$esc[38;2;56;107;51m"
+  String                  = "$esc[38;2;157;17;23m"
+  Type                    = "$esc[38;2;53;105;90m"
+  Variable                = "$esc[38;2;125;30;215m"
+  ListPredictionSelected  = "$esc[48;2;215;208;187m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;215;208;187m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/2/oasis_night_light_2.ps1
+++ b/extras/psreadline/themes/light/2/oasis_night_light_2.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/2/oasis_night_light_2.ps1
+## name: Oasis Night Light 2
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;108;69;47m"
+  Comment                 = "$esc[38;2;93;108;128m"
+  ContinuationPrompt      = "$esc[38;2;98;109;118m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;163;5;5m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;132;136;142m"
+  Keyword                 = "$esc[38;2;113;103;45m"
+  ListPrediction          = "$esc[38;2;132;136;142m"
+  ListPredictionTooltip   = "$esc[38;2;132;136;142m"
+  Member                  = "$esc[38;2;40;103;128m"
+  Number                  = "$esc[38;2;160;81;17m"
+  Operator                = "$esc[38;2;97;91;44m"
+  Parameter               = "$esc[38;2;56;108;51m"
+  String                  = "$esc[38;2;157;17;23m"
+  Type                    = "$esc[38;2;53;106;90m"
+  Variable                = "$esc[38;2;126;31;216m"
+  ListPredictionSelected  = "$esc[48;2;180;207;233m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;180;207;233m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/2/oasis_rose_light_2.ps1
+++ b/extras/psreadline/themes/light/2/oasis_rose_light_2.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/2/oasis_rose_light_2.ps1
+## name: Oasis Rose Light 2
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;104;67;45m"
+  Comment                 = "$esc[38;2;126;96;111m"
+  ContinuationPrompt      = "$esc[38;2;116;100;109m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;49;120;99m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;139;131;135m"
+  Keyword                 = "$esc[38;2;170;60;104m"
+  ListPrediction          = "$esc[38;2;139;131;135m"
+  ListPredictionTooltip   = "$esc[38;2;139;131;135m"
+  Member                  = "$esc[38;2;38;100;125m"
+  Number                  = "$esc[38;2;156;79;17m"
+  Operator                = "$esc[38;2;144;57;92m"
+  Parameter               = "$esc[38;2;54;105;49m"
+  String                  = "$esc[38;2;153;17;22m"
+  Type                    = "$esc[38;2;51;103;88m"
+  Variable                = "$esc[38;2;122;30;210m"
+  ListPredictionSelected  = "$esc[48;2;232;179;213m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;232;179;213m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/2/oasis_scorpion_light_2.ps1
+++ b/extras/psreadline/themes/light/2/oasis_scorpion_light_2.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/2/oasis_scorpion_light_2.ps1
+## name: Oasis Scorpion Light 2
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;97;63;42m"
+  Comment                 = "$esc[38;2;118;93;87m"
+  ContinuationPrompt      = "$esc[38;2;110;96;93m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;126;118;42m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;133;126;122m"
+  Keyword                 = "$esc[38;2;104;96;42m"
+  ListPrediction          = "$esc[38;2;133;126;122m"
+  ListPredictionTooltip   = "$esc[38;2;133;126;122m"
+  Member                  = "$esc[38;2;36;95;118m"
+  Number                  = "$esc[38;2;148;75;16m"
+  Operator                = "$esc[38;2;89;84;40m"
+  Parameter               = "$esc[38;2;52;99;47m"
+  String                  = "$esc[38;2;143;16;21m"
+  Type                    = "$esc[38;2;49;97;83m"
+  Variable                = "$esc[38;2;115;28;198m"
+  ListPredictionSelected  = "$esc[48;2;236;175;157m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;236;175;157m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/2/oasis_sol_light_2.ps1
+++ b/extras/psreadline/themes/light/2/oasis_sol_light_2.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/2/oasis_sol_light_2.ps1
+## name: Oasis Sol Light 2
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;93;60;40m"
+  Comment                 = "$esc[38;2;112;91;88m"
+  ContinuationPrompt      = "$esc[38;2;107;92;90m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;53;122;47m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;123;123;123m"
+  Keyword                 = "$esc[38;2;174;38;42m"
+  ListPrediction          = "$esc[38;2;123;123;123m"
+  ListPredictionTooltip   = "$esc[38;2;123;123;123m"
+  Member                  = "$esc[38;2;35;91;114m"
+  Number                  = "$esc[38;2;143;73;16m"
+  Operator                = "$esc[38;2;154;30;35m"
+  Parameter               = "$esc[38;2;50;95;45m"
+  String                  = "$esc[38;2;74;68;30m"
+  Type                    = "$esc[38;2;47;94;80m"
+  Variable                = "$esc[38;2;111;27;190m"
+  ListPredictionSelected  = "$esc[48;2;234;159;159m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;234;159;159m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/2/oasis_starlight_light_2.ps1
+++ b/extras/psreadline/themes/light/2/oasis_starlight_light_2.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/2/oasis_starlight_light_2.ps1
+## name: Oasis Starlight Light 2
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;118;75;51m"
+  Comment                 = "$esc[38;2;100;116;137m"
+  ContinuationPrompt      = "$esc[38;2;108;115;126m"
+  Default                 = "$esc[38;2;29;29;20m"
+  Emphasis                = "$esc[38;2;163;5;5m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;138;146;148m"
+  Keyword                 = "$esc[38;2;121;111;49m"
+  ListPrediction          = "$esc[38;2;138;146;148m"
+  ListPredictionTooltip   = "$esc[38;2;138;146;148m"
+  Member                  = "$esc[38;2;42;111;138m"
+  Number                  = "$esc[38;2;172;87;19m"
+  Operator                = "$esc[38;2;105;99;47m"
+  Parameter               = "$esc[38;2;60;116;55m"
+  String                  = "$esc[38;2;171;19;25m"
+  Type                    = "$esc[38;2;57;114;97m"
+  Variable                = "$esc[38;2;129;57;207m"
+  ListPredictionSelected  = "$esc[48;2;231;221;202m" + "$esc[38;2;29;29;20m"
+  Selection               = "$esc[48;2;231;221;202m" + "$esc[38;2;29;29;20m"
+}

--- a/extras/psreadline/themes/light/2/oasis_twilight_light_2.ps1
+++ b/extras/psreadline/themes/light/2/oasis_twilight_light_2.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/2/oasis_twilight_light_2.ps1
+## name: Oasis Twilight Light 2
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;86;79;29m"
+  Comment                 = "$esc[38;2;112;103;133m"
+  ContinuationPrompt      = "$esc[38;2;110;105;123m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;145;133;23m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;138;135;144m"
+  Keyword                 = "$esc[38;2;181;64;31m"
+  ListPrediction          = "$esc[38;2;138;135;144m"
+  ListPredictionTooltip   = "$esc[38;2;138;135;144m"
+  Member                  = "$esc[38;2;39;104;130m"
+  Number                  = "$esc[38;2;161;82;18m"
+  Operator                = "$esc[38;2;160;56;27m"
+  Parameter               = "$esc[38;2;56;108;51m"
+  String                  = "$esc[38;2;158;17;23m"
+  Type                    = "$esc[38;2;53;106;90m"
+  Variable                = "$esc[38;2;126;31;217m"
+  ListPredictionSelected  = "$esc[48;2;210;188;233m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;210;188;233m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/3/oasis_abyss_light_3.ps1
+++ b/extras/psreadline/themes/light/3/oasis_abyss_light_3.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/3/oasis_abyss_light_3.ps1
+## name: Oasis Abyss Light 3
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;91;59;40m"
+  Comment                 = "$esc[38;2;98;95;84m"
+  ContinuationPrompt      = "$esc[38;2;97;95;87m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;49;115;43m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;124;122;116m"
+  Keyword                 = "$esc[38;2;99;92;40m"
+  ListPrediction          = "$esc[38;2;124;122;116m"
+  ListPredictionTooltip   = "$esc[38;2;124;122;116m"
+  Member                  = "$esc[38;2;34;90;114m"
+  Number                  = "$esc[38;2;141;72;15m"
+  Operator                = "$esc[38;2;84;79;38m"
+  Parameter               = "$esc[38;2;49;94;45m"
+  String                  = "$esc[38;2;135;15;19m"
+  Type                    = "$esc[38;2;46;93;79m"
+  Variable                = "$esc[38;2;109;27;189m"
+  ListPredictionSelected  = "$esc[48;2;185;185;185m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;185;185;185m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/3/oasis_cactus_light_3.ps1
+++ b/extras/psreadline/themes/light/3/oasis_cactus_light_3.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/3/oasis_cactus_light_3.ps1
+## name: Oasis Cactus Light 3
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;106;69;46m"
+  Comment                 = "$esc[38;2;89;112;92m"
+  ContinuationPrompt      = "$esc[38;2;97;109;100m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;155;3;3m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;129;137;130m"
+  Keyword                 = "$esc[38;2;65;113;68m"
+  ListPrediction          = "$esc[38;2;129;137;130m"
+  ListPredictionTooltip   = "$esc[38;2;129;137;130m"
+  Member                  = "$esc[38;2;39;102;129m"
+  Number                  = "$esc[38;2;158;81;17m"
+  Operator                = "$esc[38;2;57;99;60m"
+  Parameter               = "$esc[38;2;124;89;18m"
+  String                  = "$esc[38;2;156;17;22m"
+  Type                    = "$esc[38;2;52;105;89m"
+  Variable                = "$esc[38;2;123;31;214m"
+  ListPredictionSelected  = "$esc[48;2;178;220;193m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;178;220;193m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/3/oasis_canyon_light_3.ps1
+++ b/extras/psreadline/themes/light/3/oasis_canyon_light_3.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/3/oasis_canyon_light_3.ps1
+## name: Oasis Canyon Light 3
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;73;67;25m"
+  Comment                 = "$esc[38;2;119;88;74m"
+  ContinuationPrompt      = "$esc[38;2;109;91;82m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;155;3;3m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;128;121;117m"
+  Keyword                 = "$esc[38;2;159;56;26m"
+  ListPrediction          = "$esc[38;2;128;121;117m"
+  ListPredictionTooltip   = "$esc[38;2;128;121;117m"
+  Member                  = "$esc[38;2;34;90;114m"
+  Number                  = "$esc[38;2;140;72;15m"
+  Operator                = "$esc[38;2;138;49;23m"
+  Parameter               = "$esc[38;2;48;94;45m"
+  String                  = "$esc[38;2;134;15;19m"
+  Type                    = "$esc[38;2;46;92;79m"
+  Variable                = "$esc[38;2;109;27;187m"
+  ListPredictionSelected  = "$esc[48;2;225;179;140m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;225;179;140m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/3/oasis_desert_light_3.ps1
+++ b/extras/psreadline/themes/light/3/oasis_desert_light_3.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/3/oasis_desert_light_3.ps1
+## name: Oasis Desert Light 3
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;108;70;47m"
+  Comment                 = "$esc[38;2;111;107;96m"
+  ContinuationPrompt      = "$esc[38;2;110;107;98m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;49;115;43m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;138;136;130m"
+  Keyword                 = "$esc[38;2;116;103;28m"
+  ListPrediction          = "$esc[38;2;138;136;130m"
+  ListPredictionTooltip   = "$esc[38;2;138;136;130m"
+  Member                  = "$esc[38;2;39;103;131m"
+  Number                  = "$esc[38;2;160;82;17m"
+  Operator                = "$esc[38;2;99;92;40m"
+  Parameter               = "$esc[38;2;56;108;51m"
+  String                  = "$esc[38;2;158;17;22m"
+  Type                    = "$esc[38;2;53;106;91m"
+  Variable                = "$esc[38;2;126;31;216m"
+  ListPredictionSelected  = "$esc[48;2;231;219;158m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;231;219;158m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/3/oasis_dune_light_3.ps1
+++ b/extras/psreadline/themes/light/3/oasis_dune_light_3.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/3/oasis_dune_light_3.ps1
+## name: Oasis Dune Light 3
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;107;69;46m"
+  Comment                 = "$esc[38;2;118;104;95m"
+  ContinuationPrompt      = "$esc[38;2;114;105;96m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;47;112;94m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;140;134;130m"
+  Keyword                 = "$esc[38;2;115;102;28m"
+  ListPrediction          = "$esc[38;2;140;134;130m"
+  ListPredictionTooltip   = "$esc[38;2;140;134;130m"
+  Member                  = "$esc[38;2;39;102;129m"
+  Number                  = "$esc[38;2;158;81;17m"
+  Operator                = "$esc[38;2;98;90;39m"
+  Parameter               = "$esc[38;2;55;107;51m"
+  String                  = "$esc[38;2;156;17;22m"
+  Type                    = "$esc[38;2;52;105;90m"
+  Variable                = "$esc[38;2;125;31;213m"
+  ListPredictionSelected  = "$esc[48;2;237;207;160m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;237;207;160m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/3/oasis_lagoon_light_3.ps1
+++ b/extras/psreadline/themes/light/3/oasis_lagoon_light_3.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/3/oasis_lagoon_light_3.ps1
+## name: Oasis Lagoon Light 3
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;105;68;46m"
+  Comment                 = "$esc[38;2;80;109;129m"
+  ContinuationPrompt      = "$esc[38;2;88;108;120m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;155;3;3m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;128;135;138m"
+  Keyword                 = "$esc[38;2;21;99;193m"
+  ListPrediction          = "$esc[38;2;128;135;138m"
+  ListPredictionTooltip   = "$esc[38;2;128;135;138m"
+  Member                  = "$esc[38;2;36;101;126m"
+  Number                  = "$esc[38;2;156;80;17m"
+  Operator                = "$esc[38;2;18;87;169m"
+  Parameter               = "$esc[38;2;54;106;50m"
+  String                  = "$esc[38;2;154;17;21m"
+  Type                    = "$esc[38;2;106;94;28m"
+  Variable                = "$esc[38;2;122;31;212m"
+  ListPredictionSelected  = "$esc[48;2;166;202;242m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;166;202;242m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/3/oasis_luna_light_3.ps1
+++ b/extras/psreadline/themes/light/3/oasis_luna_light_3.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/3/oasis_luna_light_3.ps1
+## name: Oasis Luna Light 3
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;100;65;43m"
+  Comment                 = "$esc[38;2;105;95;141m"
+  ContinuationPrompt      = "$esc[38;2;102;99;118m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;21;110;137m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;130;128;138m"
+  Keyword                 = "$esc[38;2;106;98;42m"
+  ListPrediction          = "$esc[38;2;130;128;138m"
+  ListPredictionTooltip   = "$esc[38;2;130;128;138m"
+  Member                  = "$esc[38;2;37;97;122m"
+  Number                  = "$esc[38;2;150;77;16m"
+  Operator                = "$esc[38;2;91;86;41m"
+  Parameter               = "$esc[38;2;52;101;48m"
+  String                  = "$esc[38;2;147;16;20m"
+  Type                    = "$esc[38;2;49;99;85m"
+  Variable                = "$esc[38;2;118;29;202m"
+  ListPredictionSelected  = "$esc[48;2;179;174;237m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;179;174;237m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/3/oasis_midnight_light_3.ps1
+++ b/extras/psreadline/themes/light/3/oasis_midnight_light_3.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/3/oasis_midnight_light_3.ps1
+## name: Oasis Midnight Light 3
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;96;62;42m"
+  Comment                 = "$esc[38;2;89;99;117m"
+  ContinuationPrompt      = "$esc[38;2;90;100;107m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;49;115;43m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;121;127;132m"
+  Keyword                 = "$esc[38;2;103;95;41m"
+  ListPrediction          = "$esc[38;2;121;127;132m"
+  ListPredictionTooltip   = "$esc[38;2;121;127;132m"
+  Member                  = "$esc[38;2;36;94;119m"
+  Number                  = "$esc[38;2;146;75;16m"
+  Operator                = "$esc[38;2;88;83;40m"
+  Parameter               = "$esc[38;2;51;98;47m"
+  String                  = "$esc[38;2;142;15;20m"
+  Type                    = "$esc[38;2;48;96;82m"
+  Variable                = "$esc[38;2;113;28;197m"
+  ListPredictionSelected  = "$esc[48;2;179;189;209m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;179;189;209m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/3/oasis_mirage_light_3.ps1
+++ b/extras/psreadline/themes/light/3/oasis_mirage_light_3.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/3/oasis_mirage_light_3.ps1
+## name: Oasis Mirage Light 3
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;108;70;47m"
+  Comment                 = "$esc[38;2;69;116;107m"
+  ContinuationPrompt      = "$esc[38;2;96;110;109m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;72;3;155m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;130;138;137m"
+  Keyword                 = "$esc[38;2;54;114;97m"
+  ListPrediction          = "$esc[38;2;130;138;137m"
+  ListPredictionTooltip   = "$esc[38;2;130;138;137m"
+  Member                  = "$esc[38;2;39;103;131m"
+  Number                  = "$esc[38;2;160;82;17m"
+  Operator                = "$esc[38;2;47;100;84m"
+  Parameter               = "$esc[38;2;56;108;51m"
+  String                  = "$esc[38;2;158;17;22m"
+  Type                    = "$esc[38;2;108;97;29m"
+  Variable                = "$esc[38;2;125;31;217m"
+  ListPredictionSelected  = "$esc[48;2;170;227;220m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;170;227;220m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/3/oasis_moonlight_light_3.ps1
+++ b/extras/psreadline/themes/light/3/oasis_moonlight_light_3.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/3/oasis_moonlight_light_3.ps1
+## name: Oasis Moonlight Light 3
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;102;66;44m"
+  Comment                 = "$esc[38;2;93;103;122m"
+  ContinuationPrompt      = "$esc[38;2;94;104;112m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;155;3;3m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;127;132;137m"
+  Keyword                 = "$esc[38;2;107;99;43m"
+  ListPrediction          = "$esc[38;2;127;132;137m"
+  ListPredictionTooltip   = "$esc[38;2;127;132;137m"
+  Member                  = "$esc[38;2;37;98;124m"
+  Number                  = "$esc[38;2;153;79;17m"
+  Operator                = "$esc[38;2;92;87;42m"
+  Parameter               = "$esc[38;2;53;103;49m"
+  String                  = "$esc[38;2;149;16;21m"
+  Type                    = "$esc[38;2;50;101;86m"
+  Variable                = "$esc[38;2;119;30;207m"
+  ListPredictionSelected  = "$esc[48;2;209;203;178m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;209;203;178m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/3/oasis_night_light_3.ps1
+++ b/extras/psreadline/themes/light/3/oasis_night_light_3.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/3/oasis_night_light_3.ps1
+## name: Oasis Night Light 3
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;98;63;43m"
+  Comment                 = "$esc[38;2;87;101;119m"
+  ContinuationPrompt      = "$esc[38;2;92;101;110m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;155;3;3m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;124;129;134m"
+  Keyword                 = "$esc[38;2;104;96;42m"
+  ListPrediction          = "$esc[38;2;124;129;134m"
+  ListPredictionTooltip   = "$esc[38;2;124;129;134m"
+  Member                  = "$esc[38;2;36;95;121m"
+  Number                  = "$esc[38;2;148;76;16m"
+  Operator                = "$esc[38;2;89;85;41m"
+  Parameter               = "$esc[38;2;52;100;47m"
+  String                  = "$esc[38;2;144;16;20m"
+  Type                    = "$esc[38;2;48;98;84m"
+  Variable                = "$esc[38;2;115;29;200m"
+  ListPredictionSelected  = "$esc[48;2;158;194;235m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;158;194;235m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/3/oasis_rose_light_3.ps1
+++ b/extras/psreadline/themes/light/3/oasis_rose_light_3.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/3/oasis_rose_light_3.ps1
+## name: Oasis Rose Light 3
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;96;62;42m"
+  Comment                 = "$esc[38;2;119;90;104m"
+  ContinuationPrompt      = "$esc[38;2;108;95;103m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;45;113;93m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;132;124;129m"
+  Keyword                 = "$esc[38;2;159;58;98m"
+  ListPrediction          = "$esc[38;2;132;124;129m"
+  ListPredictionTooltip   = "$esc[38;2;132;124;129m"
+  Member                  = "$esc[38;2;36;94;119m"
+  Number                  = "$esc[38;2;146;75;16m"
+  Operator                = "$esc[38;2;135;54;86m"
+  Parameter               = "$esc[38;2;51;98;47m"
+  String                  = "$esc[38;2;142;15;20m"
+  Type                    = "$esc[38;2;48;96;82m"
+  Variable                = "$esc[38;2;115;28;196m"
+  ListPredictionSelected  = "$esc[48;2;229;167;205m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;229;167;205m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/3/oasis_scorpion_light_3.ps1
+++ b/extras/psreadline/themes/light/3/oasis_scorpion_light_3.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/3/oasis_scorpion_light_3.ps1
+## name: Oasis Scorpion Light 3
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;90;58;39m"
+  Comment                 = "$esc[38;2;113;89;84m"
+  ContinuationPrompt      = "$esc[38;2;105;91;88m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;119;111;39m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;128;120;117m"
+  Keyword                 = "$esc[38;2;98;91;39m"
+  ListPrediction          = "$esc[38;2;128;120;117m"
+  ListPredictionTooltip   = "$esc[38;2;128;120;117m"
+  Member                  = "$esc[38;2;34;89;113m"
+  Number                  = "$esc[38;2;140;72;15m"
+  Operator                = "$esc[38;2;83;79;38m"
+  Parameter               = "$esc[38;2;48;93;44m"
+  String                  = "$esc[38;2;134;15;19m"
+  Type                    = "$esc[38;2;45;92;78m"
+  Variable                = "$esc[38;2;108;27;187m"
+  ListPredictionSelected  = "$esc[48;2;235;166;143m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;235;166;143m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/3/oasis_sol_light_3.ps1
+++ b/extras/psreadline/themes/light/3/oasis_sol_light_3.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/3/oasis_sol_light_3.ps1
+## name: Oasis Sol Light 3
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;83;54;36m"
+  Comment                 = "$esc[38;2;105;84;82m"
+  ContinuationPrompt      = "$esc[38;2;100;86;84m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;49;115;43m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;116;116;116m"
+  Keyword                 = "$esc[38;2;162;35;39m"
+  ListPrediction          = "$esc[38;2;116;116;116m"
+  ListPredictionTooltip   = "$esc[38;2;116;116;116m"
+  Member                  = "$esc[38;2;32;84;106m"
+  Number                  = "$esc[38;2;132;68;14m"
+  Operator                = "$esc[38;2;142;27;32m"
+  Parameter               = "$esc[38;2;45;88;42m"
+  String                  = "$esc[38;2;66;61;27m"
+  Type                    = "$esc[38;2;43;86;74m"
+  Variable                = "$esc[38;2;102;25;175m"
+  ListPredictionSelected  = "$esc[48;2;231;146;146m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;231;146;146m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/3/oasis_starlight_light_3.ps1
+++ b/extras/psreadline/themes/light/3/oasis_starlight_light_3.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/3/oasis_starlight_light_3.ps1
+## name: Oasis Starlight Light 3
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;112;73;49m"
+  Comment                 = "$esc[38;2;97;112;133m"
+  ContinuationPrompt      = "$esc[38;2;104;112;122m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;155;3;3m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;134;141;144m"
+  Keyword                 = "$esc[38;2;116;107;46m"
+  ListPrediction          = "$esc[38;2;134;141;144m"
+  ListPredictionTooltip   = "$esc[38;2;134;141;144m"
+  Member                  = "$esc[38;2;41;107;135m"
+  Number                  = "$esc[38;2;165;85;18m"
+  Operator                = "$esc[38;2;101;95;46m"
+  Parameter               = "$esc[38;2;58;112;53m"
+  String                  = "$esc[38;2;164;18;23m"
+  Type                    = "$esc[38;2;54;110;94m"
+  Variable                = "$esc[38;2;126;51;205m"
+  ListPredictionSelected  = "$esc[48;2;225;216;193m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;225;216;193m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/3/oasis_twilight_light_3.ps1
+++ b/extras/psreadline/themes/light/3/oasis_twilight_light_3.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/3/oasis_twilight_light_3.ps1
+## name: Oasis Twilight Light 3
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;81;74;27m"
+  Comment                 = "$esc[38;2;106;97;126m"
+  ContinuationPrompt      = "$esc[38;2;104;99;118m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;137;126;21m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;131;128;138m"
+  Keyword                 = "$esc[38;2;171;61;28m"
+  ListPrediction          = "$esc[38;2;131;128;138m"
+  ListPredictionTooltip   = "$esc[38;2;131;128;138m"
+  Member                  = "$esc[38;2;37;97;122m"
+  Number                  = "$esc[38;2;151;78;16m"
+  Operator                = "$esc[38;2;150;53;25m"
+  Parameter               = "$esc[38;2;52;102;48m"
+  String                  = "$esc[38;2;147;16;20m"
+  Type                    = "$esc[38;2;49;100;85m"
+  Variable                = "$esc[38;2;119;29;203m"
+  ListPredictionSelected  = "$esc[48;2;204;177;228m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;204;177;228m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/4/oasis_abyss_light_4.ps1
+++ b/extras/psreadline/themes/light/4/oasis_abyss_light_4.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/4/oasis_abyss_light_4.ps1
+## name: Oasis Abyss Light 4
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;85;54;37m"
+  Comment                 = "$esc[38;2;93;90;80m"
+  ContinuationPrompt      = "$esc[38;2;91;90;82m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;45;108;39m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;118;117;112m"
+  Keyword                 = "$esc[38;2;94;86;37m"
+  ListPrediction          = "$esc[38;2;118;117;112m"
+  ListPredictionTooltip   = "$esc[38;2;118;117;112m"
+  Member                  = "$esc[38;2;32;85;107m"
+  Number                  = "$esc[38;2;133;68;14m"
+  Operator                = "$esc[38;2;79;74;36m"
+  Parameter               = "$esc[38;2;45;89;42m"
+  String                  = "$esc[38;2;125;14;18m"
+  Type                    = "$esc[38;2;43;87;73m"
+  Variable                = "$esc[38;2;102;26;177m"
+  ListPredictionSelected  = "$esc[48;2;177;177;177m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;177;177;177m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/4/oasis_cactus_light_4.ps1
+++ b/extras/psreadline/themes/light/4/oasis_cactus_light_4.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/4/oasis_cactus_light_4.ps1
+## name: Oasis Cactus Light 4
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;102;65;44m"
+  Comment                 = "$esc[38;2;87;108;88m"
+  ContinuationPrompt      = "$esc[38;2;94;105;96m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;146;1;1m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;124;133;126m"
+  Keyword                 = "$esc[38;2;64;108;66m"
+  ListPrediction          = "$esc[38;2;124;133;126m"
+  ListPredictionTooltip   = "$esc[38;2;124;133;126m"
+  Member                  = "$esc[38;2;38;98;123m"
+  Number                  = "$esc[38;2;153;78;17m"
+  Operator                = "$esc[38;2;54;95;57m"
+  Parameter               = "$esc[38;2;119;86;17m"
+  String                  = "$esc[38;2;149;16;21m"
+  Type                    = "$esc[38;2;50;101;85m"
+  Variable                = "$esc[38;2;119;30;205m"
+  ListPredictionSelected  = "$esc[48;2;168;215;186m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;168;215;186m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/4/oasis_canyon_light_4.ps1
+++ b/extras/psreadline/themes/light/4/oasis_canyon_light_4.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/4/oasis_canyon_light_4.ps1
+## name: Oasis Canyon Light 4
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;68;62;23m"
+  Comment                 = "$esc[38;2;114;83;70m"
+  ContinuationPrompt      = "$esc[38;2;104;87;78m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;146;1;1m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;121;116;113m"
+  Keyword                 = "$esc[38;2;151;54;26m"
+  ListPrediction          = "$esc[38;2;121;116;113m"
+  ListPredictionTooltip   = "$esc[38;2;121;116;113m"
+  Member                  = "$esc[38;2;33;85;107m"
+  Number                  = "$esc[38;2;134;68;15m"
+  Operator                = "$esc[38;2;131;47;23m"
+  Parameter               = "$esc[38;2;46;89;43m"
+  String                  = "$esc[38;2;126;14;18m"
+  Type                    = "$esc[38;2;43;88;74m"
+  Variable                = "$esc[38;2;104;26;177m"
+  ListPredictionSelected  = "$esc[48;2;223;171;128m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;223;171;128m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/4/oasis_desert_light_4.ps1
+++ b/extras/psreadline/themes/light/4/oasis_desert_light_4.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/4/oasis_desert_light_4.ps1
+## name: Oasis Desert Light 4
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;104;67;46m"
+  Comment                 = "$esc[38;2;108;104;93m"
+  ContinuationPrompt      = "$esc[38;2;106;104;96m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;45;108;39m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;134;133;127m"
+  Keyword                 = "$esc[38;2;112;101;27m"
+  ListPrediction          = "$esc[38;2;134;133;127m"
+  ListPredictionTooltip   = "$esc[38;2;134;133;127m"
+  Member                  = "$esc[38;2;38;100;126m"
+  Number                  = "$esc[38;2;156;80;17m"
+  Operator                = "$esc[38;2;96;88;38m"
+  Parameter               = "$esc[38;2;54;105;50m"
+  String                  = "$esc[38;2;153;17;22m"
+  Type                    = "$esc[38;2;51;103;87m"
+  Variable                = "$esc[38;2;122;31;208m"
+  ListPredictionSelected  = "$esc[48;2;228;213;146m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;228;213;146m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/4/oasis_dune_light_4.ps1
+++ b/extras/psreadline/themes/light/4/oasis_dune_light_4.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/4/oasis_dune_light_4.ps1
+## name: Oasis Dune Light 4
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;102;65;44m"
+  Comment                 = "$esc[38;2;113;100;91m"
+  ContinuationPrompt      = "$esc[38;2;111;101;92m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;43;105;88m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;135;130;125m"
+  Keyword                 = "$esc[38;2;110;99;27m"
+  ListPrediction          = "$esc[38;2;135;130;125m"
+  ListPredictionTooltip   = "$esc[38;2;135;130;125m"
+  Member                  = "$esc[38;2;38;98;124m"
+  Number                  = "$esc[38;2;153;78;17m"
+  Operator                = "$esc[38;2;94;87;38m"
+  Parameter               = "$esc[38;2;53;103;49m"
+  String                  = "$esc[38;2;149;16;21m"
+  Type                    = "$esc[38;2;50;101;85m"
+  Variable                = "$esc[38;2;120;30;205m"
+  ListPredictionSelected  = "$esc[48;2;236;199;147m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;236;199;147m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/4/oasis_lagoon_light_4.ps1
+++ b/extras/psreadline/themes/light/4/oasis_lagoon_light_4.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/4/oasis_lagoon_light_4.ps1
+## name: Oasis Lagoon Light 4
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;98;63;43m"
+  Comment                 = "$esc[38;2;75;103;122m"
+  ContinuationPrompt      = "$esc[38;2;84;102;114m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;146;1;1m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;123;129;133m"
+  Keyword                 = "$esc[38;2;20;94;183m"
+  ListPrediction          = "$esc[38;2;123;129;133m"
+  ListPredictionTooltip   = "$esc[38;2;123;129;133m"
+  Member                  = "$esc[38;2;35;96;119m"
+  Number                  = "$esc[38;2;149;76;16m"
+  Operator                = "$esc[38;2;17;82;161m"
+  Parameter               = "$esc[38;2;51;100;48m"
+  String                  = "$esc[38;2;144;16;20m"
+  Type                    = "$esc[38;2;100;89;27m"
+  Variable                = "$esc[38;2;115;29;200m"
+  ListPredictionSelected  = "$esc[48;2;154;194;240m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;154;194;240m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/4/oasis_luna_light_4.ps1
+++ b/extras/psreadline/themes/light/4/oasis_luna_light_4.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/4/oasis_luna_light_4.ps1
+## name: Oasis Luna Light 4
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;91;58;40m"
+  Comment                 = "$esc[38;2;98;88;131m"
+  ContinuationPrompt      = "$esc[38;2;94;92;110m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;19;104;129m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;122;120;131m"
+  Keyword                 = "$esc[38;2;99;91;39m"
+  ListPrediction          = "$esc[38;2;122;120;131m"
+  ListPredictionTooltip   = "$esc[38;2;122;120;131m"
+  Member                  = "$esc[38;2;34;89;113m"
+  Number                  = "$esc[38;2;140;72;15m"
+  Operator                = "$esc[38;2;84;79;38m"
+  Parameter               = "$esc[38;2;48;94;45m"
+  String                  = "$esc[38;2;134;15;19m"
+  Type                    = "$esc[38;2;46;92;78m"
+  Variable                = "$esc[38;2;109;27;186m"
+  ListPredictionSelected  = "$esc[48;2;167;162;233m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;167;162;233m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/4/oasis_midnight_light_4.ps1
+++ b/extras/psreadline/themes/light/4/oasis_midnight_light_4.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/4/oasis_midnight_light_4.ps1
+## name: Oasis Midnight Light 4
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;89;57;39m"
+  Comment                 = "$esc[38;2;83;94;111m"
+  ContinuationPrompt      = "$esc[38;2;86;94;101m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;45;108;39m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;115;121;126m"
+  Keyword                 = "$esc[38;2;98;90;39m"
+  ListPrediction          = "$esc[38;2;115;121;126m"
+  ListPredictionTooltip   = "$esc[38;2;115;121;126m"
+  Member                  = "$esc[38;2;34;88;111m"
+  Number                  = "$esc[38;2;138;71;15m"
+  Operator                = "$esc[38;2;82;78;38m"
+  Parameter               = "$esc[38;2;47;93;44m"
+  String                  = "$esc[38;2;132;14;19m"
+  Type                    = "$esc[38;2;45;91;77m"
+  Variable                = "$esc[38;2;107;27;185m"
+  ListPredictionSelected  = "$esc[48;2;169;181;203m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;169;181;203m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/4/oasis_mirage_light_4.ps1
+++ b/extras/psreadline/themes/light/4/oasis_mirage_light_4.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/4/oasis_mirage_light_4.ps1
+## name: Oasis Mirage Light 4
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;104;67;46m"
+  Comment                 = "$esc[38;2;67;112;104m"
+  ContinuationPrompt      = "$esc[38;2;94;107;106m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;67;1;146m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;127;134;134m"
+  Keyword                 = "$esc[38;2;53;110;94m"
+  ListPrediction          = "$esc[38;2;127;134;134m"
+  ListPredictionTooltip   = "$esc[38;2;127;134;134m"
+  Member                  = "$esc[38;2;38;100;126m"
+  Number                  = "$esc[38;2;155;79;17m"
+  Operator                = "$esc[38;2;46;97;81m"
+  Parameter               = "$esc[38;2;54;105;50m"
+  String                  = "$esc[38;2;152;17;22m"
+  Type                    = "$esc[38;2;105;94;28m"
+  Variable                = "$esc[38;2;121;31;210m"
+  ListPredictionSelected  = "$esc[48;2;159;222;215m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;159;222;215m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/4/oasis_moonlight_light_4.ps1
+++ b/extras/psreadline/themes/light/4/oasis_moonlight_light_4.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/4/oasis_moonlight_light_4.ps1
+## name: Oasis Moonlight Light 4
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;97;62;42m"
+  Comment                 = "$esc[38;2;88;100;118m"
+  ContinuationPrompt      = "$esc[38;2;91;100;108m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;146;1;1m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;123;127;132m"
+  Keyword                 = "$esc[38;2;104;95;41m"
+  ListPrediction          = "$esc[38;2;123;127;132m"
+  ListPredictionTooltip   = "$esc[38;2;123;127;132m"
+  Member                  = "$esc[38;2;36;95;119m"
+  Number                  = "$esc[38;2;147;75;16m"
+  Operator                = "$esc[38;2;88;83;40m"
+  Parameter               = "$esc[38;2;50;99;47m"
+  String                  = "$esc[38;2;142;15;20m"
+  Type                    = "$esc[38;2;48;97;82m"
+  Variable                = "$esc[38;2;114;29;198m"
+  ListPredictionSelected  = "$esc[48;2;203;198;168m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;203;198;168m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/4/oasis_night_light_4.ps1
+++ b/extras/psreadline/themes/light/4/oasis_night_light_4.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/4/oasis_night_light_4.ps1
+## name: Oasis Night Light 4
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;91;58;40m"
+  Comment                 = "$esc[38;2;82;96;113m"
+  ContinuationPrompt      = "$esc[38;2;87;95;103m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;146;1;1m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;118;123;127m"
+  Keyword                 = "$esc[38;2;99;91;39m"
+  ListPrediction          = "$esc[38;2;118;123;127m"
+  ListPredictionTooltip   = "$esc[38;2;118;123;127m"
+  Member                  = "$esc[38;2;34;90;113m"
+  Number                  = "$esc[38;2;140;72;15m"
+  Operator                = "$esc[38;2;84;79;38m"
+  Parameter               = "$esc[38;2;48;94;45m"
+  String                  = "$esc[38;2;134;15;19m"
+  Type                    = "$esc[38;2;46;92;78m"
+  Variable                = "$esc[38;2;108;27;187m"
+  ListPredictionSelected  = "$esc[48;2;140;187;238m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;140;187;238m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/4/oasis_rose_light_4.ps1
+++ b/extras/psreadline/themes/light/4/oasis_rose_light_4.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/4/oasis_rose_light_4.ps1
+## name: Oasis Rose Light 4
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;89;57;39m"
+  Comment                 = "$esc[38;2;113;85;99m"
+  ContinuationPrompt      = "$esc[38;2;103;89;97m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;42;106;87m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;124;118;122m"
+  Keyword                 = "$esc[38;2;150;54;92m"
+  ListPrediction          = "$esc[38;2;124;118;122m"
+  ListPredictionTooltip   = "$esc[38;2;124;118;122m"
+  Member                  = "$esc[38;2;34;88;111m"
+  Number                  = "$esc[38;2;138;70;15m"
+  Operator                = "$esc[38;2;126;50;79m"
+  Parameter               = "$esc[38;2;47;92;44m"
+  String                  = "$esc[38;2;131;14;18m"
+  Type                    = "$esc[38;2;45;90;76m"
+  Variable                = "$esc[38;2;107;27;182m"
+  ListPredictionSelected  = "$esc[48;2;227;154;198m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;227;154;198m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/4/oasis_scorpion_light_4.ps1
+++ b/extras/psreadline/themes/light/4/oasis_scorpion_light_4.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/4/oasis_scorpion_light_4.ps1
+## name: Oasis Scorpion Light 4
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;84;54;36m"
+  Comment                 = "$esc[38;2;107;84;79m"
+  ContinuationPrompt      = "$esc[38;2;99;86;83m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;113;105;35m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;121;115;113m"
+  Keyword                 = "$esc[38;2;93;85;37m"
+  ListPrediction          = "$esc[38;2;121;115;113m"
+  ListPredictionTooltip   = "$esc[38;2;121;115;113m"
+  Member                  = "$esc[38;2;32;84;106m"
+  Number                  = "$esc[38;2;132;67;14m"
+  Operator                = "$esc[38;2;78;73;36m"
+  Parameter               = "$esc[38;2;45;88;42m"
+  String                  = "$esc[38;2;124;13;17m"
+  Type                    = "$esc[38;2;43;86;73m"
+  Variable                = "$esc[38;2;101;26;175m"
+  ListPredictionSelected  = "$esc[48;2;233;156;130m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;233;156;130m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/4/oasis_sol_light_4.ps1
+++ b/extras/psreadline/themes/light/4/oasis_sol_light_4.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/4/oasis_sol_light_4.ps1
+## name: Oasis Sol Light 4
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;74;48;32m"
+  Comment                 = "$esc[38;2;96;78;75m"
+  ContinuationPrompt      = "$esc[38;2;93;79;77m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;45;108;39m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;109;109;109m"
+  Keyword                 = "$esc[38;2;150;32;36m"
+  ListPrediction          = "$esc[38;2;109;109;109m"
+  ListPredictionTooltip   = "$esc[38;2;109;109;109m"
+  Member                  = "$esc[38;2;29;77;97m"
+  Number                  = "$esc[38;2;122;62;13m"
+  Operator                = "$esc[38;2;129;26;29m"
+  Parameter               = "$esc[38;2;41;81;39m"
+  String                  = "$esc[38;2;59;54;23m"
+  Type                    = "$esc[38;2;39;79;67m"
+  Variable                = "$esc[38;2;93;23;159m"
+  ListPredictionSelected  = "$esc[48;2;228;133;133m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;228;133;133m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/4/oasis_starlight_light_4.ps1
+++ b/extras/psreadline/themes/light/4/oasis_starlight_light_4.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/4/oasis_starlight_light_4.ps1
+## name: Oasis Starlight Light 4
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;108;69;47m"
+  Comment                 = "$esc[38;2;93;109;128m"
+  ContinuationPrompt      = "$esc[38;2;101;108;117m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;146;1;1m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;130;138;139m"
+  Keyword                 = "$esc[38;2;113;104;45m"
+  ListPrediction          = "$esc[38;2;130;138;139m"
+  ListPredictionTooltip   = "$esc[38;2;130;138;139m"
+  Member                  = "$esc[38;2;39;103;130m"
+  Number                  = "$esc[38;2;160;82;17m"
+  Operator                = "$esc[38;2;97;92;44m"
+  Parameter               = "$esc[38;2;55;108;52m"
+  String                  = "$esc[38;2;158;17;22m"
+  Type                    = "$esc[38;2;52;106;89m"
+  Variable                = "$esc[38;2;121;48;199m"
+  ListPredictionSelected  = "$esc[48;2;220;211;183m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;220;211;183m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/4/oasis_twilight_light_4.ps1
+++ b/extras/psreadline/themes/light/4/oasis_twilight_light_4.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/4/oasis_twilight_light_4.ps1
+## name: Oasis Twilight Light 4
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;74;68;25m"
+  Comment                 = "$esc[38;2;99;92;118m"
+  ContinuationPrompt      = "$esc[38;2;98;93;110m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;130;119;18m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;124;122;131m"
+  Keyword                 = "$esc[38;2;160;57;28m"
+  ListPrediction          = "$esc[38;2;124;122;131m"
+  ListPredictionTooltip   = "$esc[38;2;124;122;131m"
+  Member                  = "$esc[38;2;35;91;114m"
+  Number                  = "$esc[38;2;142;73;15m"
+  Operator                = "$esc[38;2;140;50;24m"
+  Parameter               = "$esc[38;2;49;96;46m"
+  String                  = "$esc[38;2;136;15;19m"
+  Type                    = "$esc[38;2;46;94;79m"
+  Variable                = "$esc[38;2;111;28;189m"
+  ListPredictionSelected  = "$esc[48;2;197;167;224m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;197;167;224m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/5/oasis_abyss_light_5.ps1
+++ b/extras/psreadline/themes/light/5/oasis_abyss_light_5.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/5/oasis_abyss_light_5.ps1
+## name: Oasis Abyss Light 5
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;78;50;34m"
+  Comment                 = "$esc[38;2;88;85;75m"
+  ContinuationPrompt      = "$esc[38;2;88;85;78m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;41;102;36m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;113;112;106m"
+  Keyword                 = "$esc[38;2;89;82;35m"
+  ListPrediction          = "$esc[38;2;113;112;106m"
+  ListPredictionTooltip   = "$esc[38;2;113;112;106m"
+  Member                  = "$esc[38;2;30;80;100m"
+  Number                  = "$esc[38;2;127;64;14m"
+  Operator                = "$esc[38;2;74;70;34m"
+  Parameter               = "$esc[38;2;43;84;39m"
+  String                  = "$esc[38;2;116;13;17m"
+  Type                    = "$esc[38;2;41;82;70m"
+  Variable                = "$esc[38;2;97;23;167m"
+  ListPredictionSelected  = "$esc[48;2;170;170;170m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;170;170;170m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/5/oasis_cactus_light_5.ps1
+++ b/extras/psreadline/themes/light/5/oasis_cactus_light_5.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/5/oasis_cactus_light_5.ps1
+## name: Oasis Cactus Light 5
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;96;62;42m"
+  Comment                 = "$esc[38;2;82;104;84m"
+  ContinuationPrompt      = "$esc[38;2;90;101;93m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;138;0;0m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;120;128;123m"
+  Keyword                 = "$esc[38;2;61;104;63m"
+  ListPrediction          = "$esc[38;2;120;128;123m"
+  ListPredictionTooltip   = "$esc[38;2;120;128;123m"
+  Member                  = "$esc[38;2;35;94;118m"
+  Number                  = "$esc[38;2;147;74;16m"
+  Operator                = "$esc[38;2;53;90;55m"
+  Parameter               = "$esc[38;2;113;82;16m"
+  String                  = "$esc[38;2;142;15;20m"
+  Type                    = "$esc[38;2;48;96;82m"
+  Variable                = "$esc[38;2;114;28;197m"
+  ListPredictionSelected  = "$esc[48;2;157;210;176m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;157;210;176m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/5/oasis_canyon_light_5.ps1
+++ b/extras/psreadline/themes/light/5/oasis_canyon_light_5.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/5/oasis_canyon_light_5.ps1
+## name: Oasis Canyon Light 5
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;64;58;21m"
+  Comment                 = "$esc[38;2;108;79;67m"
+  ContinuationPrompt      = "$esc[38;2;99;82;74m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;138;0;0m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;117;111;108m"
+  Keyword                 = "$esc[38;2;143;51;24m"
+  ListPrediction          = "$esc[38;2;117;111;108m"
+  ListPredictionTooltip   = "$esc[38;2;117;111;108m"
+  Member                  = "$esc[38;2;30;81;101m"
+  Number                  = "$esc[38;2;127;64;14m"
+  Operator                = "$esc[38;2;123;43;20m"
+  Parameter               = "$esc[38;2;44;84;40m"
+  String                  = "$esc[38;2;117;13;17m"
+  Type                    = "$esc[38;2;41;83;71m"
+  Variable                = "$esc[38;2;97;24;168m"
+  ListPredictionSelected  = "$esc[48;2;220;163;116m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;220;163;116m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/5/oasis_desert_light_5.ps1
+++ b/extras/psreadline/themes/light/5/oasis_desert_light_5.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/5/oasis_desert_light_5.ps1
+## name: Oasis Desert Light 5
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;100;65;44m"
+  Comment                 = "$esc[38;2;105;102;90m"
+  ContinuationPrompt      = "$esc[38;2;105;102;93m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;41;102;36m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;131;130;124m"
+  Keyword                 = "$esc[38;2;108;98;26m"
+  ListPrediction          = "$esc[38;2;131;130;124m"
+  ListPredictionTooltip   = "$esc[38;2;131;130;124m"
+  Member                  = "$esc[38;2;36;98;122m"
+  Number                  = "$esc[38;2;152;77;17m"
+  Operator                = "$esc[38;2;93;86;37m"
+  Parameter               = "$esc[38;2;53;102;48m"
+  String                  = "$esc[38;2;148;16;21m"
+  Type                    = "$esc[38;2;50;100;85m"
+  Variable                = "$esc[38;2;118;29;204m"
+  ListPredictionSelected  = "$esc[48;2;225;210;134m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;225;210;134m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/5/oasis_dune_light_5.ps1
+++ b/extras/psreadline/themes/light/5/oasis_dune_light_5.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/5/oasis_dune_light_5.ps1
+## name: Oasis Dune Light 5
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;97;63;42m"
+  Comment                 = "$esc[38;2;109;97;89m"
+  ContinuationPrompt      = "$esc[38;2;106;98;89m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;39;98;82m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;132;126;121m"
+  Keyword                 = "$esc[38;2;105;95;26m"
+  ListPrediction          = "$esc[38;2;132;126;121m"
+  ListPredictionTooltip   = "$esc[38;2;132;126;121m"
+  Member                  = "$esc[38;2;35;95;119m"
+  Number                  = "$esc[38;2;148;75;16m"
+  Operator                = "$esc[38;2;90;83;36m"
+  Parameter               = "$esc[38;2;51;99;47m"
+  String                  = "$esc[38;2;143;15;21m"
+  Type                    = "$esc[38;2;49;97;83m"
+  Variable                = "$esc[38;2;115;28;198m"
+  ListPredictionSelected  = "$esc[48;2;232;194;135m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;232;194;135m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/5/oasis_lagoon_light_5.ps1
+++ b/extras/psreadline/themes/light/5/oasis_lagoon_light_5.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/5/oasis_lagoon_light_5.ps1
+## name: Oasis Lagoon Light 5
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;91;59;40m"
+  Comment                 = "$esc[38;2;71;98;114m"
+  ContinuationPrompt      = "$esc[38;2;79;97;107m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;138;0;0m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;116;123;126m"
+  Keyword                 = "$esc[38;2;19;88;174m"
+  ListPrediction          = "$esc[38;2;116;123;126m"
+  ListPredictionTooltip   = "$esc[38;2;116;123;126m"
+  Member                  = "$esc[38;2;33;90;112m"
+  Number                  = "$esc[38;2;141;71;15m"
+  Operator                = "$esc[38;2;16;77;151m"
+  Parameter               = "$esc[38;2;49;94;44m"
+  String                  = "$esc[38;2;134;15;19m"
+  Type                    = "$esc[38;2;94;84;25m"
+  Variable                = "$esc[38;2;109;26;188m"
+  ListPredictionSelected  = "$esc[48;2;140;186;238m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;140;186;238m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/5/oasis_luna_light_5.ps1
+++ b/extras/psreadline/themes/light/5/oasis_luna_light_5.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/5/oasis_luna_light_5.ps1
+## name: Oasis Luna Light 5
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;80;52;35m"
+  Comment                 = "$esc[38;2;89;81;121m"
+  ContinuationPrompt      = "$esc[38;2;87;85;101m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;17;97;121m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;114;112;121m"
+  Keyword                 = "$esc[38;2;90;83;36m"
+  ListPrediction          = "$esc[38;2;114;112;121m"
+  ListPredictionTooltip   = "$esc[38;2;114;112;121m"
+  Member                  = "$esc[38;2;30;82;102m"
+  Number                  = "$esc[38;2;129;65;14m"
+  Operator                = "$esc[38;2;76;71;35m"
+  Parameter               = "$esc[38;2;44;85;40m"
+  String                  = "$esc[38;2;119;13;17m"
+  Type                    = "$esc[38;2;42;84;72m"
+  Variable                = "$esc[38;2;99;24;170m"
+  ListPredictionSelected  = "$esc[48;2;157;149;230m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;157;149;230m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/5/oasis_midnight_light_5.ps1
+++ b/extras/psreadline/themes/light/5/oasis_midnight_light_5.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/5/oasis_midnight_light_5.ps1
+## name: Oasis Midnight Light 5
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;81;53;35m"
+  Comment                 = "$esc[38;2;78;88;102m"
+  ContinuationPrompt      = "$esc[38;2;81;89;95m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;41;102;36m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;110;115;119m"
+  Keyword                 = "$esc[38;2;91;84;36m"
+  ListPrediction          = "$esc[38;2;110;115;119m"
+  ListPredictionTooltip   = "$esc[38;2;110;115;119m"
+  Member                  = "$esc[38;2;31;83;104m"
+  Number                  = "$esc[38;2;131;66;14m"
+  Operator                = "$esc[38;2;77;72;35m"
+  Parameter               = "$esc[38;2;45;86;41m"
+  String                  = "$esc[38;2;121;13;17m"
+  Type                    = "$esc[38;2;42;85;72m"
+  Variable                = "$esc[38;2;100;24;172m"
+  ListPredictionSelected  = "$esc[48;2;160;172;197m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;160;172;197m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/5/oasis_mirage_light_5.ps1
+++ b/extras/psreadline/themes/light/5/oasis_mirage_light_5.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/5/oasis_mirage_light_5.ps1
+## name: Oasis Mirage Light 5
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;99;64;43m"
+  Comment                 = "$esc[38;2;65;109;102m"
+  ContinuationPrompt      = "$esc[38;2;91;103;102m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;62;0;138m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;123;131;131m"
+  Keyword                 = "$esc[38;2;49;107;90m"
+  ListPrediction          = "$esc[38;2;123;131;131m"
+  ListPredictionTooltip   = "$esc[38;2;123;131;131m"
+  Member                  = "$esc[38;2;36;97;121m"
+  Number                  = "$esc[38;2;151;76;16m"
+  Operator                = "$esc[38;2;44;93;80m"
+  Parameter               = "$esc[38;2;52;101;48m"
+  String                  = "$esc[38;2;146;16;21m"
+  Type                    = "$esc[38;2;101;91;27m"
+  Variable                = "$esc[38;2;117;28;203m"
+  ListPredictionSelected  = "$esc[48;2;147;219;212m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;147;219;212m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/5/oasis_moonlight_light_5.ps1
+++ b/extras/psreadline/themes/light/5/oasis_moonlight_light_5.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/5/oasis_moonlight_light_5.ps1
+## name: Oasis Moonlight Light 5
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;91;59;40m"
+  Comment                 = "$esc[38;2;84;96;111m"
+  ContinuationPrompt      = "$esc[38;2;87;96;102m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;138;0;0m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;118;123;127m"
+  Keyword                 = "$esc[38;2;99;91;40m"
+  ListPrediction          = "$esc[38;2;118;123;127m"
+  ListPredictionTooltip   = "$esc[38;2;118;123;127m"
+  Member                  = "$esc[38;2;34;90;113m"
+  Number                  = "$esc[38;2;142;72;15m"
+  Operator                = "$esc[38;2;85;79;39m"
+  Parameter               = "$esc[38;2;49;94;44m"
+  String                  = "$esc[38;2;134;15;19m"
+  Type                    = "$esc[38;2;46;92;79m"
+  Variable                = "$esc[38;2;109;26;188m"
+  ListPredictionSelected  = "$esc[48;2;198;190;158m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;198;190;158m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/5/oasis_night_light_5.ps1
+++ b/extras/psreadline/themes/light/5/oasis_night_light_5.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/5/oasis_night_light_5.ps1
+## name: Oasis Night Light 5
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;85;55;37m"
+  Comment                 = "$esc[38;2;79;92;108m"
+  ContinuationPrompt      = "$esc[38;2;83;91;100m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;138;0;0m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;113;118;122m"
+  Keyword                 = "$esc[38;2;94;87;38m"
+  ListPrediction          = "$esc[38;2;113;118;122m"
+  ListPredictionTooltip   = "$esc[38;2;113;118;122m"
+  Member                  = "$esc[38;2;32;86;107m"
+  Number                  = "$esc[38;2;135;68;15m"
+  Operator                = "$esc[38;2;80;75;37m"
+  Parameter               = "$esc[38;2;46;89;42m"
+  String                  = "$esc[38;2;127;14;18m"
+  Type                    = "$esc[38;2;44;88;75m"
+  Variable                = "$esc[38;2;104;25;179m"
+  ListPredictionSelected  = "$esc[48;2;132;183;230m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;132;183;230m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/5/oasis_rose_light_5.ps1
+++ b/extras/psreadline/themes/light/5/oasis_rose_light_5.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/5/oasis_rose_light_5.ps1
+## name: Oasis Rose Light 5
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;80;52;35m"
+  Comment                 = "$esc[38;2;104;79;92m"
+  ContinuationPrompt      = "$esc[38;2;95;83;91m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;38;100;81m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;119;111;116m"
+  Keyword                 = "$esc[38;2;140;49;86m"
+  ListPrediction          = "$esc[38;2;119;111;116m"
+  ListPredictionTooltip   = "$esc[38;2;119;111;116m"
+  Member                  = "$esc[38;2;30;82;102m"
+  Number                  = "$esc[38;2;129;65;14m"
+  Operator                = "$esc[38;2;116;46;74m"
+  Parameter               = "$esc[38;2;44;85;40m"
+  String                  = "$esc[38;2;119;13;17m"
+  Type                    = "$esc[38;2;42;84;71m"
+  Variable                = "$esc[38;2;98;24;170m"
+  ListPredictionSelected  = "$esc[48;2;222;143;193m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;222;143;193m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/5/oasis_scorpion_light_5.ps1
+++ b/extras/psreadline/themes/light/5/oasis_scorpion_light_5.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/5/oasis_scorpion_light_5.ps1
+## name: Oasis Scorpion Light 5
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;75;49;33m"
+  Comment                 = "$esc[38;2;100;78;73m"
+  ContinuationPrompt      = "$esc[38;2;92;80;79m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;106;98;32m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;114;108;105m"
+  Keyword                 = "$esc[38;2;86;79;34m"
+  ListPrediction          = "$esc[38;2;114;108;105m"
+  ListPredictionTooltip   = "$esc[38;2;114;108;105m"
+  Member                  = "$esc[38;2;29;78;98m"
+  Number                  = "$esc[38;2;123;62;13m"
+  Operator                = "$esc[38;2;72;67;33m"
+  Parameter               = "$esc[38;2;42;81;38m"
+  String                  = "$esc[38;2;112;12;16m"
+  Type                    = "$esc[38;2;40;80;68m"
+  Variable                = "$esc[38;2;94;23;162m"
+  ListPredictionSelected  = "$esc[48;2;229;145;117m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;229;145;117m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/5/oasis_sol_light_5.ps1
+++ b/extras/psreadline/themes/light/5/oasis_sol_light_5.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/5/oasis_sol_light_5.ps1
+## name: Oasis Sol Light 5
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;65;42;28m"
+  Comment                 = "$esc[38;2;89;72;70m"
+  ContinuationPrompt      = "$esc[38;2;85;73;71m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;41;102;36m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;102;102;102m"
+  Keyword                 = "$esc[38;2;137;31;33m"
+  ListPrediction          = "$esc[38;2;102;102;102m"
+  ListPredictionTooltip   = "$esc[38;2;102;102;102m"
+  Member                  = "$esc[38;2;26;70;88m"
+  Number                  = "$esc[38;2;113;57;12m"
+  Operator                = "$esc[38;2;117;23;26m"
+  Parameter               = "$esc[38;2;38;73;34m"
+  String                  = "$esc[38;2;51;47;21m"
+  Type                    = "$esc[38;2;36;72;61m"
+  Variable                = "$esc[38;2;84;20;145m"
+  ListPredictionSelected  = "$esc[48;2;225;121;121m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;225;121;121m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/5/oasis_starlight_light_5.ps1
+++ b/extras/psreadline/themes/light/5/oasis_starlight_light_5.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/5/oasis_starlight_light_5.ps1
+## name: Oasis Starlight Light 5
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;102;66;45m"
+  Comment                 = "$esc[38;2;90;104;123m"
+  ContinuationPrompt      = "$esc[38;2;96;104;113m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;138;0;0m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;125;133;135m"
+  Keyword                 = "$esc[38;2;108;100;43m"
+  ListPrediction          = "$esc[38;2;125;133;135m"
+  ListPredictionTooltip   = "$esc[38;2;125;133;135m"
+  Member                  = "$esc[38;2;37;99;124m"
+  Number                  = "$esc[38;2;154;78;17m"
+  Operator                = "$esc[38;2;93;87;43m"
+  Parameter               = "$esc[38;2;53;103;48m"
+  String                  = "$esc[38;2;150;16;22m"
+  Type                    = "$esc[38;2;51;101;87m"
+  Variable                = "$esc[38;2;116;46;189m"
+  ListPredictionSelected  = "$esc[48;2;215;203;172m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;215;203;172m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/psreadline/themes/light/5/oasis_twilight_light_5.ps1
+++ b/extras/psreadline/themes/light/5/oasis_twilight_light_5.ps1
@@ -1,0 +1,27 @@
+# extras/psreadline/themes/light/5/oasis_twilight_light_5.ps1
+## name: Oasis Twilight Light 5
+## author: uhs-robert
+
+$esc = [char]0x1B
+
+Set-PSReadLineOption -Colors @{
+  Command                 = "$esc[38;2;67;61;22m"
+  Comment                 = "$esc[38;2;94;85;111m"
+  ContinuationPrompt      = "$esc[38;2;91;87;102m"
+  Default                 = "$esc[38;2;24;24;17m"
+  Emphasis                = "$esc[38;2;122;111;16m"
+  Error                   = "$esc[38;2;112;24;24m"
+  InlinePrediction        = "$esc[38;2;118;115;124m"
+  Keyword                 = "$esc[38;2;149;53;25m"
+  ListPrediction          = "$esc[38;2;118;115;124m"
+  ListPredictionTooltip   = "$esc[38;2;118;115;124m"
+  Member                  = "$esc[38;2;31;84;106m"
+  Number                  = "$esc[38;2;133;67;14m"
+  Operator                = "$esc[38;2;129;46;21m"
+  Parameter               = "$esc[38;2;46;88;41m"
+  String                  = "$esc[38;2;124;13;18m"
+  Type                    = "$esc[38;2;43;86;74m"
+  Variable                = "$esc[38;2;102;25;176m"
+  ListPredictionSelected  = "$esc[48;2;189;155;220m" + "$esc[38;2;24;24;17m"
+  Selection               = "$esc[48;2;189;155;220m" + "$esc[38;2;24;24;17m"
+}

--- a/extras/windows-terminal/README.md
+++ b/extras/windows-terminal/README.md
@@ -1,0 +1,61 @@
+# Windows Terminal Setup
+
+Windows Terminal color schemes are stored as JSON objects inside the `"schemes"` array of your `settings.json`.
+
+### Installation
+
+1. Open Windows Terminal, then open the Command Palette (`Ctrl+Shift+P`) and run "Open JSON file" (or go to `Settings -> Open JSON file`).
+2. Open the theme you want (example: `themes/dark/oasis_mirage_dark.json`) and copy its whole JSON object.
+3. Paste it as a new entry into the top-level `"schemes"` array in `settings.json`:
+
+```json
+{
+  "schemes": [
+    {
+      "name": "Oasis Mirage Dark",
+      "background": "#111C22",
+      "foreground": "#F5F5DC",
+      "cursorColor": "#F0E68C",
+      "selectionBackground": "#21333B",
+      "black": "#111C22",
+      "red": "#FF7979",
+      "green": "#7FCF78",
+      "yellow": "#F0E68C",
+      "blue": "#81C0FF",
+      "purple": "#C695FF",
+      "cyan": "#69C3AA",
+      "white": "#F5F5DC",
+      "brightBlack": "#587270",
+      "brightRed": "#FFA0A0",
+      "brightGreen": "#A3E39A",
+      "brightYellow": "#F8B471",
+      "brightBlue": "#87CEEB",
+      "brightPurple": "#D2ADFF",
+      "brightCyan": "#8AD3BE",
+      "brightWhite": "#FFFFF0"
+    }
+  ]
+}
+```
+
+4. Save the file. Windows Terminal picks up changes automatically.
+
+### Usage
+
+The scheme's `name` field is what you reference as `colorScheme` in a profile, or under `"defaults"` to apply it everywhere:
+
+```json
+"profiles": {
+  "defaults": {
+    "colorScheme": "Oasis Mirage Dark"
+  }
+}
+```
+
+Or set it on a single profile instead of `"defaults"` to scope it to just that shell.
+
+### Theme Structure
+
+- **Dark themes**: `themes/dark/oasis_<variant>_dark.json`
+- **Light themes**: `themes/light/<intensity>/oasis_<variant>_light_<intensity>.json`
+  - Intensity levels: `1` (lightest) to `5` (darkest)

--- a/extras/windows-terminal/generate_windowsterminal.lua
+++ b/extras/windows-terminal/generate_windowsterminal.lua
@@ -1,0 +1,73 @@
+#!/usr/bin/env lua
+-- extras/windows-terminal/generate_windowsterminal.lua
+-- Generates Windows Terminal JSON color schemes from Oasis color palettes
+
+package.path = package.path .. ";./lua/?.lua;./lua/?/init.lua"
+local Utils = require("oasis.utils")
+local File = require("oasis.lib.file")
+
+local function generate_windows_terminal_theme(variant_name, palette)
+  local display_name = Utils.format_display_name(variant_name)
+  local is_light = palette.light_mode or false
+  local cursor_color = is_light and palette.syntax.statement or palette.theme.cursor
+
+  -- stylua: ignore start
+  local fields = {
+    { "name",                display_name },
+    { "background",          palette.bg.core },
+    { "foreground",          palette.fg.core },
+    { "cursorColor",         cursor_color },
+    { "selectionBackground", palette.ui.visual.bg },
+    { "black",               palette.terminal.black },
+    { "red",                 palette.terminal.red },
+    { "green",               palette.terminal.green },
+    { "yellow",              palette.terminal.yellow },
+    { "blue",                palette.terminal.blue },
+    { "purple",              palette.terminal.magenta },
+    { "cyan",                palette.terminal.cyan },
+    { "white",               palette.terminal.white },
+    { "brightBlack",         palette.terminal.bright_black },
+    { "brightRed",           palette.terminal.bright_red },
+    { "brightGreen",         palette.terminal.bright_green },
+    { "brightYellow",        palette.terminal.bright_yellow },
+    { "brightBlue",          palette.terminal.bright_blue },
+    { "brightPurple",        palette.terminal.bright_magenta },
+    { "brightCyan",          palette.terminal.bright_cyan },
+    { "brightWhite",         palette.terminal.bright_white },
+  }
+  -- stylua: ignore end
+
+  local lines = { "{" }
+  for i, field in ipairs(fields) do
+    local comma = i < #fields and "," or ""
+    lines[#lines + 1] = string.format('  "%s": "%s"%s', field[1], field[2], comma)
+  end
+  lines[#lines + 1] = "}"
+
+  return table.concat(lines, "\n")
+end
+
+local function main()
+  print("\n=== Oasis Windows Terminal Theme Generator ===\n")
+
+  local palette_names = Utils.get_palette_names()
+  if #palette_names == 0 then
+    print("Error: No palette files found in lua/oasis/color_palettes/")
+    return
+  end
+
+  print(string.format("Found %d palette(s)\n", #palette_names))
+
+  local success_count, error_count = Utils.for_each_palette_variant(function(name, palette, mode, intensity)
+    local output_path, variant_name = Utils.build_variant_path("extras/windows-terminal", "json", name, mode, intensity)
+    local theme = generate_windows_terminal_theme(variant_name, palette)
+    File.write(output_path, theme)
+    print(string.format("✓ Generated: %s", output_path))
+  end)
+
+  print(string.format("\n=== Summary ==="))
+  print(string.format("Success: %d", success_count))
+  print(string.format("Errors: %d\n", error_count))
+end
+
+main()

--- a/extras/windows-terminal/themes/dark/oasis_abyss_dark.json
+++ b/extras/windows-terminal/themes/dark/oasis_abyss_dark.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Abyss Dark",
+  "background": "#000000",
+  "foreground": "#F5F5DC",
+  "cursorColor": "#F0E68C",
+  "selectionBackground": "#532E2E",
+  "black": "#000000",
+  "red": "#FF7979",
+  "green": "#7FCF78",
+  "yellow": "#F0E68C",
+  "blue": "#81C0FF",
+  "purple": "#C695FF",
+  "cyan": "#69C3AA",
+  "white": "#F5F5DC",
+  "brightBlack": "#605C4D",
+  "brightRed": "#FFA0A0",
+  "brightGreen": "#A3E39A",
+  "brightYellow": "#F8B471",
+  "brightBlue": "#87CEEB",
+  "brightPurple": "#D2ADFF",
+  "brightCyan": "#8AD3BE",
+  "brightWhite": "#FFFFF0"
+}

--- a/extras/windows-terminal/themes/dark/oasis_cactus_dark.json
+++ b/extras/windows-terminal/themes/dark/oasis_cactus_dark.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Cactus Dark",
+  "background": "#151E17",
+  "foreground": "#F5F5DC",
+  "cursorColor": "#F0E68C",
+  "selectionBackground": "#2F3D33",
+  "black": "#151E17",
+  "red": "#FF7979",
+  "green": "#7FCF78",
+  "yellow": "#F0E68C",
+  "blue": "#81C0FF",
+  "purple": "#C695FF",
+  "cyan": "#69C3AA",
+  "white": "#F5F5DC",
+  "brightBlack": "#5B7360",
+  "brightRed": "#FFA0A0",
+  "brightGreen": "#A3E39A",
+  "brightYellow": "#F8B471",
+  "brightBlue": "#87CEEB",
+  "brightPurple": "#D2ADFF",
+  "brightCyan": "#8AD3BE",
+  "brightWhite": "#FFFFF0"
+}

--- a/extras/windows-terminal/themes/dark/oasis_canyon_dark.json
+++ b/extras/windows-terminal/themes/dark/oasis_canyon_dark.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Canyon Dark",
+  "background": "#261612",
+  "foreground": "#F5F5DC",
+  "cursorColor": "#F0E68C",
+  "selectionBackground": "#483228",
+  "black": "#261612",
+  "red": "#FF7979",
+  "green": "#7FCF78",
+  "yellow": "#F0E68C",
+  "blue": "#81C0FF",
+  "purple": "#C695FF",
+  "cyan": "#69C3AA",
+  "white": "#F5F5DC",
+  "brightBlack": "#9A6549",
+  "brightRed": "#FFA0A0",
+  "brightGreen": "#A3E39A",
+  "brightYellow": "#F8B471",
+  "brightBlue": "#87CEEB",
+  "brightPurple": "#D2ADFF",
+  "brightCyan": "#8AD3BE",
+  "brightWhite": "#FFFFF0"
+}

--- a/extras/windows-terminal/themes/dark/oasis_desert_dark.json
+++ b/extras/windows-terminal/themes/dark/oasis_desert_dark.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Desert Dark",
+  "background": "#262626",
+  "foreground": "#F5F5DC",
+  "cursorColor": "#F0E68C",
+  "selectionBackground": "#433F38",
+  "black": "#262626",
+  "red": "#FF7979",
+  "green": "#7FCF78",
+  "yellow": "#F0E68C",
+  "blue": "#81C0FF",
+  "purple": "#C695FF",
+  "cyan": "#69C3AA",
+  "white": "#F5F5DC",
+  "brightBlack": "#77725F",
+  "brightRed": "#FFA0A0",
+  "brightGreen": "#A3E39A",
+  "brightYellow": "#F8B471",
+  "brightBlue": "#87CEEB",
+  "brightPurple": "#D2ADFF",
+  "brightCyan": "#8AD3BE",
+  "brightWhite": "#FFFFF0"
+}

--- a/extras/windows-terminal/themes/dark/oasis_dune_dark.json
+++ b/extras/windows-terminal/themes/dark/oasis_dune_dark.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Dune Dark",
+  "background": "#27211B",
+  "foreground": "#F5F5DC",
+  "cursorColor": "#F0E68C",
+  "selectionBackground": "#463E34",
+  "black": "#27211B",
+  "red": "#FF7979",
+  "green": "#7FCF78",
+  "yellow": "#F0E68C",
+  "blue": "#81C0FF",
+  "purple": "#C695FF",
+  "cyan": "#69C3AA",
+  "white": "#F5F5DC",
+  "brightBlack": "#826D5A",
+  "brightRed": "#FFA0A0",
+  "brightGreen": "#A3E39A",
+  "brightYellow": "#F8B471",
+  "brightBlue": "#87CEEB",
+  "brightPurple": "#D2ADFF",
+  "brightCyan": "#8AD3BE",
+  "brightWhite": "#FFFFF0"
+}

--- a/extras/windows-terminal/themes/dark/oasis_lagoon_dark.json
+++ b/extras/windows-terminal/themes/dark/oasis_lagoon_dark.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Lagoon Dark",
+  "background": "#101825",
+  "foreground": "#F5F5DC",
+  "cursorColor": "#F0E68C",
+  "selectionBackground": "#22385C",
+  "black": "#101825",
+  "red": "#FF7979",
+  "green": "#7FCF78",
+  "yellow": "#F0E68C",
+  "blue": "#81C0FF",
+  "purple": "#C695FF",
+  "cyan": "#69C3AA",
+  "white": "#F5F5DC",
+  "brightBlack": "#3B6A87",
+  "brightRed": "#FFA0A0",
+  "brightGreen": "#A3E39A",
+  "brightYellow": "#F8B471",
+  "brightBlue": "#87CEEB",
+  "brightPurple": "#D2ADFF",
+  "brightCyan": "#8AD3BE",
+  "brightWhite": "#FFFFF0"
+}

--- a/extras/windows-terminal/themes/dark/oasis_luna_dark.json
+++ b/extras/windows-terminal/themes/dark/oasis_luna_dark.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Luna Dark",
+  "background": "#0D0D2B",
+  "foreground": "#F5F5DC",
+  "cursorColor": "#F0E68C",
+  "selectionBackground": "#433F38",
+  "black": "#0D0D2B",
+  "red": "#FF7979",
+  "green": "#7FCF78",
+  "yellow": "#F0E68C",
+  "blue": "#81C0FF",
+  "purple": "#C695FF",
+  "cyan": "#69C3AA",
+  "white": "#F5F5DC",
+  "brightBlack": "#8A82B3",
+  "brightRed": "#FFA0A0",
+  "brightGreen": "#A3E39A",
+  "brightYellow": "#F8B471",
+  "brightBlue": "#87CEEB",
+  "brightPurple": "#D2ADFF",
+  "brightCyan": "#8AD3BE",
+  "brightWhite": "#FFFFF0"
+}

--- a/extras/windows-terminal/themes/dark/oasis_midnight_dark.json
+++ b/extras/windows-terminal/themes/dark/oasis_midnight_dark.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Midnight Dark",
+  "background": "#0C0E13",
+  "foreground": "#F5F5DC",
+  "cursorColor": "#F0E68C",
+  "selectionBackground": "#1E2A38",
+  "black": "#0C0E13",
+  "red": "#FF7979",
+  "green": "#7FCF78",
+  "yellow": "#F0E68C",
+  "blue": "#81C0FF",
+  "purple": "#C695FF",
+  "cyan": "#69C3AA",
+  "white": "#F5F5DC",
+  "brightBlack": "#4E6578",
+  "brightRed": "#FFA0A0",
+  "brightGreen": "#A3E39A",
+  "brightYellow": "#F8B471",
+  "brightBlue": "#87CEEB",
+  "brightPurple": "#D2ADFF",
+  "brightCyan": "#8AD3BE",
+  "brightWhite": "#FFFFF0"
+}

--- a/extras/windows-terminal/themes/dark/oasis_mirage_dark.json
+++ b/extras/windows-terminal/themes/dark/oasis_mirage_dark.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Mirage Dark",
+  "background": "#111C22",
+  "foreground": "#F5F5DC",
+  "cursorColor": "#F0E68C",
+  "selectionBackground": "#21333B",
+  "black": "#111C22",
+  "red": "#FF7979",
+  "green": "#7FCF78",
+  "yellow": "#F0E68C",
+  "blue": "#81C0FF",
+  "purple": "#C695FF",
+  "cyan": "#69C3AA",
+  "white": "#F5F5DC",
+  "brightBlack": "#587270",
+  "brightRed": "#FFA0A0",
+  "brightGreen": "#A3E39A",
+  "brightYellow": "#F8B471",
+  "brightBlue": "#87CEEB",
+  "brightPurple": "#D2ADFF",
+  "brightCyan": "#8AD3BE",
+  "brightWhite": "#FFFFF0"
+}

--- a/extras/windows-terminal/themes/dark/oasis_moonlight_dark.json
+++ b/extras/windows-terminal/themes/dark/oasis_moonlight_dark.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Moonlight Dark",
+  "background": "#0C0E13",
+  "foreground": "#F5F5DC",
+  "cursorColor": "#F0E68C",
+  "selectionBackground": "#24364D",
+  "black": "#0C0E13",
+  "red": "#FF7979",
+  "green": "#7FCF78",
+  "yellow": "#F0E68C",
+  "blue": "#81C0FF",
+  "purple": "#C695FF",
+  "cyan": "#69C3AA",
+  "white": "#F5F5DC",
+  "brightBlack": "#4E6578",
+  "brightRed": "#FFA0A0",
+  "brightGreen": "#A3E39A",
+  "brightYellow": "#F8B471",
+  "brightBlue": "#87CEEB",
+  "brightPurple": "#D2ADFF",
+  "brightCyan": "#8AD3BE",
+  "brightWhite": "#FFFFF0"
+}

--- a/extras/windows-terminal/themes/dark/oasis_night_dark.json
+++ b/extras/windows-terminal/themes/dark/oasis_night_dark.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Night Dark",
+  "background": "#08111C",
+  "foreground": "#F5F5DC",
+  "cursorColor": "#F0E68C",
+  "selectionBackground": "#24364D",
+  "black": "#08111C",
+  "red": "#FF7979",
+  "green": "#7FCF78",
+  "yellow": "#F0E68C",
+  "blue": "#81C0FF",
+  "purple": "#C695FF",
+  "cyan": "#69C3AA",
+  "white": "#F5F5DC",
+  "brightBlack": "#536B83",
+  "brightRed": "#FFA0A0",
+  "brightGreen": "#A3E39A",
+  "brightYellow": "#F8B471",
+  "brightBlue": "#87CEEB",
+  "brightPurple": "#D2ADFF",
+  "brightCyan": "#8AD3BE",
+  "brightWhite": "#FFFFF0"
+}

--- a/extras/windows-terminal/themes/dark/oasis_rose_dark.json
+++ b/extras/windows-terminal/themes/dark/oasis_rose_dark.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Rose Dark",
+  "background": "#2C1724",
+  "foreground": "#F5F5DC",
+  "cursorColor": "#F0E68C",
+  "selectionBackground": "#4E3747",
+  "black": "#2C1724",
+  "red": "#FF7979",
+  "green": "#7FCF78",
+  "yellow": "#F0E68C",
+  "blue": "#81C0FF",
+  "purple": "#C695FF",
+  "cyan": "#69C3AA",
+  "white": "#F5F5DC",
+  "brightBlack": "#816175",
+  "brightRed": "#FFA0A0",
+  "brightGreen": "#A3E39A",
+  "brightYellow": "#F8B471",
+  "brightBlue": "#87CEEB",
+  "brightPurple": "#D2ADFF",
+  "brightCyan": "#8AD3BE",
+  "brightWhite": "#FFFFF0"
+}

--- a/extras/windows-terminal/themes/dark/oasis_scorpion_dark.json
+++ b/extras/windows-terminal/themes/dark/oasis_scorpion_dark.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Scorpion Dark",
+  "background": "#1A0500",
+  "foreground": "#F5F5DC",
+  "cursorColor": "#F0E68C",
+  "selectionBackground": "#5A3824",
+  "black": "#1A0500",
+  "red": "#FF7979",
+  "green": "#7FCF78",
+  "yellow": "#F0E68C",
+  "blue": "#81C0FF",
+  "purple": "#C695FF",
+  "cyan": "#69C3AA",
+  "white": "#F5F5DC",
+  "brightBlack": "#9A6F66",
+  "brightRed": "#FFA0A0",
+  "brightGreen": "#A3E39A",
+  "brightYellow": "#F8B471",
+  "brightBlue": "#87CEEB",
+  "brightPurple": "#D2ADFF",
+  "brightCyan": "#8AD3BE",
+  "brightWhite": "#FFFFF0"
+}

--- a/extras/windows-terminal/themes/dark/oasis_sol_dark.json
+++ b/extras/windows-terminal/themes/dark/oasis_sol_dark.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Sol Dark",
+  "background": "#271311",
+  "foreground": "#F5F5DC",
+  "cursorColor": "#F0E68C",
+  "selectionBackground": "#432823",
+  "black": "#271311",
+  "red": "#FF7979",
+  "green": "#7FCF78",
+  "yellow": "#F0E68C",
+  "blue": "#81C0FF",
+  "purple": "#C695FF",
+  "cyan": "#69C3AA",
+  "white": "#F5F5DC",
+  "brightBlack": "#83615B",
+  "brightRed": "#FFA0A0",
+  "brightGreen": "#A3E39A",
+  "brightYellow": "#F8B471",
+  "brightBlue": "#87CEEB",
+  "brightPurple": "#D2ADFF",
+  "brightCyan": "#8AD3BE",
+  "brightWhite": "#FFFFF0"
+}

--- a/extras/windows-terminal/themes/dark/oasis_starlight_dark.json
+++ b/extras/windows-terminal/themes/dark/oasis_starlight_dark.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Starlight Dark",
+  "background": "#000000",
+  "foreground": "#F5F5DC",
+  "cursorColor": "#F0E68C",
+  "selectionBackground": "#4D4528",
+  "black": "#000000",
+  "red": "#FF7979",
+  "green": "#7FCF78",
+  "yellow": "#F0E68C",
+  "blue": "#81C0FF",
+  "purple": "#C695FF",
+  "cyan": "#69C3AA",
+  "white": "#F5F5DC",
+  "brightBlack": "#4F5B6B",
+  "brightRed": "#FFA0A0",
+  "brightGreen": "#A3E39A",
+  "brightYellow": "#F8B471",
+  "brightBlue": "#87CEEB",
+  "brightPurple": "#D2ADFF",
+  "brightCyan": "#8AD3BE",
+  "brightWhite": "#FFFFF0"
+}

--- a/extras/windows-terminal/themes/dark/oasis_twilight_dark.json
+++ b/extras/windows-terminal/themes/dark/oasis_twilight_dark.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Twilight Dark",
+  "background": "#1B1320",
+  "foreground": "#F5F5DC",
+  "cursorColor": "#F0E68C",
+  "selectionBackground": "#362343",
+  "black": "#1B1320",
+  "red": "#FF7979",
+  "green": "#7FCF78",
+  "yellow": "#F0E68C",
+  "blue": "#81C0FF",
+  "purple": "#C695FF",
+  "cyan": "#69C3AA",
+  "white": "#F5F5DC",
+  "brightBlack": "#71609A",
+  "brightRed": "#FFA0A0",
+  "brightGreen": "#A3E39A",
+  "brightYellow": "#F8B471",
+  "brightBlue": "#87CEEB",
+  "brightPurple": "#D2ADFF",
+  "brightCyan": "#8AD3BE",
+  "brightWhite": "#FFFFF0"
+}

--- a/extras/windows-terminal/themes/light/1/oasis_abyss_light_1.json
+++ b/extras/windows-terminal/themes/light/1/oasis_abyss_light_1.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Abyss Light 1",
+  "background": "#e7e7e7",
+  "foreground": "#181811",
+  "cursorColor": "#6e642c",
+  "selectionBackground": "#c8c8c8",
+  "black": "#414141",
+  "red": "#b01212",
+  "green": "#376133",
+  "yellow": "#5f5920",
+  "blue": "#14589e",
+  "purple": "#7422d5",
+  "cyan": "#365f54",
+  "white": "#43431f",
+  "brightBlack": "#494038",
+  "brightRed": "#b01212",
+  "brightGreen": "#34622e",
+  "brightYellow": "#814a13",
+  "brightBlue": "#225e77",
+  "brightPurple": "#7323d5",
+  "brightCyan": "#346054",
+  "brightWhite": "#44440e"
+}

--- a/extras/windows-terminal/themes/light/1/oasis_cactus_light_1.json
+++ b/extras/windows-terminal/themes/light/1/oasis_cactus_light_1.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Cactus Light 1",
+  "background": "#f1f9f4",
+  "foreground": "#1c1c13",
+  "cursorColor": "#467949",
+  "selectionBackground": "#c6e7d2",
+  "black": "#4b4b4b",
+  "red": "#c11313",
+  "green": "#3d6c39",
+  "yellow": "#696223",
+  "blue": "#1661ae",
+  "purple": "#7f30de",
+  "cyan": "#3c695d",
+  "white": "#4d4d24",
+  "brightBlack": "#534940",
+  "brightRed": "#c11313",
+  "brightGreen": "#396c32",
+  "brightYellow": "#8f5215",
+  "brightBlue": "#266883",
+  "brightPurple": "#7f31de",
+  "brightCyan": "#396a5c",
+  "brightWhite": "#4d4d10"
+}

--- a/extras/windows-terminal/themes/light/1/oasis_canyon_light_1.json
+++ b/extras/windows-terminal/themes/light/1/oasis_canyon_light_1.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Canyon Light 1",
+  "background": "#f4e3d5",
+  "foreground": "#181811",
+  "cursorColor": "#ae3d1d",
+  "selectionBackground": "#e7c3a5",
+  "black": "#414141",
+  "red": "#ae1111",
+  "green": "#376033",
+  "yellow": "#5e581f",
+  "blue": "#13589d",
+  "purple": "#7322d3",
+  "cyan": "#355e53",
+  "white": "#43431f",
+  "brightBlack": "#493f38",
+  "brightRed": "#ae1111",
+  "brightGreen": "#33612d",
+  "brightYellow": "#804913",
+  "brightBlue": "#225d76",
+  "brightPurple": "#7222d4",
+  "brightCyan": "#335f53",
+  "brightWhite": "#43430e"
+}

--- a/extras/windows-terminal/themes/light/1/oasis_desert_light_1.json
+++ b/extras/windows-terminal/themes/light/1/oasis_desert_light_1.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Desert Light 1",
+  "background": "#f9f6e7",
+  "foreground": "#1b1b13",
+  "cursorColor": "#7a6d1c",
+  "selectionBackground": "#ede4b6",
+  "black": "#4a4a4a",
+  "red": "#c01313",
+  "green": "#3d6b38",
+  "yellow": "#686123",
+  "blue": "#1561ad",
+  "purple": "#7f2edd",
+  "cyan": "#3b685c",
+  "white": "#4c4c24",
+  "brightBlack": "#534840",
+  "brightRed": "#c01313",
+  "brightGreen": "#396b32",
+  "brightYellow": "#8e5115",
+  "brightBlue": "#256782",
+  "brightPurple": "#7e2fdd",
+  "brightCyan": "#39695c",
+  "brightWhite": "#4c4c10"
+}

--- a/extras/windows-terminal/themes/light/1/oasis_dune_light_1.json
+++ b/extras/windows-terminal/themes/light/1/oasis_dune_light_1.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Dune Light 1",
+  "background": "#fcf6ee",
+  "foreground": "#1c1c13",
+  "cursorColor": "#7a6e1d",
+  "selectionBackground": "#f3daba",
+  "black": "#4a4a4a",
+  "red": "#c11313",
+  "green": "#3d6b39",
+  "yellow": "#696223",
+  "blue": "#1661ae",
+  "purple": "#7f30de",
+  "cyan": "#3b695c",
+  "white": "#4c4c24",
+  "brightBlack": "#534940",
+  "brightRed": "#c11313",
+  "brightGreen": "#396c32",
+  "brightYellow": "#8e5215",
+  "brightBlue": "#266883",
+  "brightPurple": "#7e30dd",
+  "brightCyan": "#396a5c",
+  "brightWhite": "#4d4d10"
+}

--- a/extras/windows-terminal/themes/light/1/oasis_lagoon_light_1.json
+++ b/extras/windows-terminal/themes/light/1/oasis_lagoon_light_1.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Lagoon Light 1",
+  "background": "#f2f7fd",
+  "foreground": "#1b1b13",
+  "cursorColor": "#176bd1",
+  "selectionBackground": "#bdd6f5",
+  "black": "#4a4a4a",
+  "red": "#c01313",
+  "green": "#3d6b39",
+  "yellow": "#696223",
+  "blue": "#1561ae",
+  "purple": "#7f2fde",
+  "cyan": "#3b695c",
+  "white": "#4c4c24",
+  "brightBlack": "#534840",
+  "brightRed": "#c01313",
+  "brightGreen": "#396c32",
+  "brightYellow": "#8e5215",
+  "brightBlue": "#266783",
+  "brightPurple": "#7e30dd",
+  "brightCyan": "#39695c",
+  "brightWhite": "#4d4d10"
+}

--- a/extras/windows-terminal/themes/light/1/oasis_luna_light_1.json
+++ b/extras/windows-terminal/themes/light/1/oasis_luna_light_1.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Luna Light 1",
+  "background": "#f3f3fc",
+  "foreground": "#191911",
+  "cursorColor": "#766c2f",
+  "selectionBackground": "#c2c2f0",
+  "black": "#494949",
+  "red": "#be1313",
+  "green": "#3c6938",
+  "yellow": "#676022",
+  "blue": "#1560ab",
+  "purple": "#7d2cdd",
+  "cyan": "#3a675b",
+  "white": "#4b4b23",
+  "brightBlack": "#51473f",
+  "brightRed": "#be1313",
+  "brightGreen": "#386a31",
+  "brightYellow": "#8c5015",
+  "brightBlue": "#256681",
+  "brightPurple": "#7d2ddd",
+  "brightCyan": "#38685b",
+  "brightWhite": "#4b4b10"
+}

--- a/extras/windows-terminal/themes/light/1/oasis_midnight_light_1.json
+++ b/extras/windows-terminal/themes/light/1/oasis_midnight_light_1.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Midnight Light 1",
+  "background": "#eceff4",
+  "foreground": "#181811",
+  "cursorColor": "#73692e",
+  "selectionBackground": "#c5cede",
+  "black": "#464646",
+  "red": "#b81212",
+  "green": "#3a6636",
+  "yellow": "#645d21",
+  "blue": "#155da6",
+  "purple": "#7a26dc",
+  "cyan": "#396458",
+  "white": "#484822",
+  "brightBlack": "#4e443c",
+  "brightRed": "#b81212",
+  "brightGreen": "#366730",
+  "brightYellow": "#884e14",
+  "brightBlue": "#24637d",
+  "brightPurple": "#7927dc",
+  "brightCyan": "#366458",
+  "brightWhite": "#48480f"
+}

--- a/extras/windows-terminal/themes/light/1/oasis_mirage_light_1.json
+++ b/extras/windows-terminal/themes/light/1/oasis_mirage_light_1.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Mirage Light 1",
+  "background": "#effaf8",
+  "foreground": "#1c1c14",
+  "cursorColor": "#387968",
+  "selectionBackground": "#c0ebe4",
+  "black": "#4b4b4b",
+  "red": "#c21313",
+  "green": "#3d6c39",
+  "yellow": "#696323",
+  "blue": "#1662af",
+  "purple": "#8030de",
+  "cyan": "#3c6a5d",
+  "white": "#4d4d24",
+  "brightBlack": "#544941",
+  "brightRed": "#c21414",
+  "brightGreen": "#396d33",
+  "brightYellow": "#8f5215",
+  "brightBlue": "#266884",
+  "brightPurple": "#7f31de",
+  "brightCyan": "#396a5d",
+  "brightWhite": "#4d4d10"
+}

--- a/extras/windows-terminal/themes/light/1/oasis_moonlight_light_1.json
+++ b/extras/windows-terminal/themes/light/1/oasis_moonlight_light_1.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Moonlight Light 1",
+  "background": "#f3f2eb",
+  "foreground": "#181811",
+  "cursorColor": "#756b2f",
+  "selectionBackground": "#dcd9c5",
+  "black": "#484848",
+  "red": "#bc1313",
+  "green": "#3b6837",
+  "yellow": "#665f22",
+  "blue": "#155fa9",
+  "purple": "#7c2add",
+  "cyan": "#3a665a",
+  "white": "#494922",
+  "brightBlack": "#50463e",
+  "brightRed": "#bc1313",
+  "brightGreen": "#376931",
+  "brightYellow": "#8a4f15",
+  "brightBlue": "#24647f",
+  "brightPurple": "#7b2bdd",
+  "brightCyan": "#37665a",
+  "brightWhite": "#4a4a10"
+}

--- a/extras/windows-terminal/themes/light/1/oasis_night_light_1.json
+++ b/extras/windows-terminal/themes/light/1/oasis_night_light_1.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Night Light 1",
+  "background": "#f3f5f7",
+  "foreground": "#1a1a12",
+  "cursorColor": "#776d2f",
+  "selectionBackground": "#ced6de",
+  "black": "#494949",
+  "red": "#bf1313",
+  "green": "#3c6a38",
+  "yellow": "#686123",
+  "blue": "#1560ac",
+  "purple": "#7e2ddd",
+  "cyan": "#3b685b",
+  "white": "#4b4b23",
+  "brightBlack": "#52473f",
+  "brightRed": "#bf1313",
+  "brightGreen": "#386b32",
+  "brightYellow": "#8d5115",
+  "brightBlue": "#256681",
+  "brightPurple": "#7d2edd",
+  "brightCyan": "#38685b",
+  "brightWhite": "#4c4c10"
+}

--- a/extras/windows-terminal/themes/light/1/oasis_rose_light_1.json
+++ b/extras/windows-terminal/themes/light/1/oasis_rose_light_1.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Rose Light 1",
+  "background": "#faeef5",
+  "foreground": "#181811",
+  "cursorColor": "#b3406e",
+  "selectionBackground": "#ecbfd9",
+  "black": "#474747",
+  "red": "#bb1313",
+  "green": "#3b6837",
+  "yellow": "#655f22",
+  "blue": "#155ea9",
+  "purple": "#7b29dd",
+  "cyan": "#39665a",
+  "white": "#494922",
+  "brightBlack": "#50453d",
+  "brightRed": "#bb1313",
+  "brightGreen": "#376831",
+  "brightYellow": "#8a4f14",
+  "brightBlue": "#24647f",
+  "brightPurple": "#7b2adc",
+  "brightCyan": "#376659",
+  "brightWhite": "#4a4a10"
+}

--- a/extras/windows-terminal/themes/light/1/oasis_scorpion_light_1.json
+++ b/extras/windows-terminal/themes/light/1/oasis_scorpion_light_1.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Scorpion Light 1",
+  "background": "#f9e4dd",
+  "foreground": "#181811",
+  "cursorColor": "#6f652c",
+  "selectionBackground": "#f0bba9",
+  "black": "#424242",
+  "red": "#b11212",
+  "green": "#386234",
+  "yellow": "#605a20",
+  "blue": "#14599f",
+  "purple": "#7522d6",
+  "cyan": "#366055",
+  "white": "#444420",
+  "brightBlack": "#4a4039",
+  "brightRed": "#b11212",
+  "brightGreen": "#34632e",
+  "brightYellow": "#824b13",
+  "brightBlue": "#225f78",
+  "brightPurple": "#7423d7",
+  "brightCyan": "#346054",
+  "brightWhite": "#44440e"
+}

--- a/extras/windows-terminal/themes/light/1/oasis_sol_light_1.json
+++ b/extras/windows-terminal/themes/light/1/oasis_sol_light_1.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Sol Light 1",
+  "background": "#f8dddd",
+  "foreground": "#181811",
+  "cursorColor": "#b9292c",
+  "selectionBackground": "#eeaaaa",
+  "black": "#3f3f3f",
+  "red": "#ab1111",
+  "green": "#365f32",
+  "yellow": "#5c561f",
+  "blue": "#13569a",
+  "purple": "#7121cf",
+  "cyan": "#345d52",
+  "white": "#41411e",
+  "brightBlack": "#473d36",
+  "brightRed": "#ab1111",
+  "brightGreen": "#325f2c",
+  "brightYellow": "#7e4813",
+  "brightBlue": "#215b74",
+  "brightPurple": "#7022d0",
+  "brightCyan": "#325d51",
+  "brightWhite": "#41410e"
+}

--- a/extras/windows-terminal/themes/light/1/oasis_starlight_light_1.json
+++ b/extras/windows-terminal/themes/light/1/oasis_starlight_light_1.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Starlight Light 1",
+  "background": "#faf9f5",
+  "foreground": "#1e1e14",
+  "cursorColor": "#796f31",
+  "selectionBackground": "#e6e1cc",
+  "black": "#4c4c4c",
+  "red": "#c31414",
+  "green": "#3e6d39",
+  "yellow": "#6a6323",
+  "blue": "#1663b1",
+  "purple": "#8132de",
+  "cyan": "#3c6a5e",
+  "white": "#4e4e24",
+  "brightBlack": "#554a41",
+  "brightRed": "#c31414",
+  "brightGreen": "#3a6e33",
+  "brightYellow": "#905315",
+  "brightBlue": "#266985",
+  "brightPurple": "#8033de",
+  "brightCyan": "#3a6b5e",
+  "brightWhite": "#4e4e11"
+}

--- a/extras/windows-terminal/themes/light/1/oasis_twilight_light_1.json
+++ b/extras/windows-terminal/themes/light/1/oasis_twilight_light_1.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Twilight Light 1",
+  "background": "#f8f4fb",
+  "foreground": "#1b1b13",
+  "cursorColor": "#be4320",
+  "selectionBackground": "#dbc7eb",
+  "black": "#4a4a4a",
+  "red": "#c01313",
+  "green": "#3c6a38",
+  "yellow": "#686123",
+  "blue": "#1561ad",
+  "purple": "#7e2edd",
+  "cyan": "#3b685c",
+  "white": "#4c4c23",
+  "brightBlack": "#524840",
+  "brightRed": "#c01313",
+  "brightGreen": "#386b32",
+  "brightYellow": "#8d5115",
+  "brightBlue": "#256782",
+  "brightPurple": "#7e2fdd",
+  "brightCyan": "#39695c",
+  "brightWhite": "#4c4c10"
+}

--- a/extras/windows-terminal/themes/light/2/oasis_abyss_light_2.json
+++ b/extras/windows-terminal/themes/light/2/oasis_abyss_light_2.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Abyss Light 2",
+  "background": "#e0e0e0",
+  "foreground": "#181811",
+  "cursorColor": "#69602a",
+  "selectionBackground": "#c1c1c1",
+  "black": "#3d3d3d",
+  "red": "#a81111",
+  "green": "#345c31",
+  "yellow": "#5b551e",
+  "blue": "#135497",
+  "purple": "#6f21ca",
+  "cyan": "#335b50",
+  "white": "#3f3f1d",
+  "brightBlack": "#453b35",
+  "brightRed": "#a81111",
+  "brightGreen": "#315d2b",
+  "brightYellow": "#7b4712",
+  "brightBlue": "#205971",
+  "brightPurple": "#6e21cb",
+  "brightCyan": "#315b4f",
+  "brightWhite": "#3f3f0d"
+}

--- a/extras/windows-terminal/themes/light/2/oasis_cactus_light_2.json
+++ b/extras/windows-terminal/themes/light/2/oasis_cactus_light_2.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Cactus Light 2",
+  "background": "#e7f4eb",
+  "foreground": "#181811",
+  "cursorColor": "#447447",
+  "selectionBackground": "#bde1c8",
+  "black": "#474747",
+  "red": "#ba1313",
+  "green": "#3b6737",
+  "yellow": "#655e22",
+  "blue": "#155ea8",
+  "purple": "#7b29dc",
+  "cyan": "#396559",
+  "white": "#494922",
+  "brightBlack": "#50453e",
+  "brightRed": "#ba1313",
+  "brightGreen": "#376830",
+  "brightYellow": "#8a4f14",
+  "brightBlue": "#24647e",
+  "brightPurple": "#7a2adc",
+  "brightCyan": "#376658",
+  "brightWhite": "#4a4a0f"
+}

--- a/extras/windows-terminal/themes/light/2/oasis_canyon_light_2.json
+++ b/extras/windows-terminal/themes/light/2/oasis_canyon_light_2.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Canyon Light 2",
+  "background": "#f1dbc9",
+  "foreground": "#181811",
+  "cursorColor": "#a73b1d",
+  "selectionBackground": "#e4bb98",
+  "black": "#3d3d3d",
+  "red": "#a61111",
+  "green": "#345c31",
+  "yellow": "#5a541e",
+  "blue": "#125395",
+  "purple": "#6e21c8",
+  "cyan": "#335a4f",
+  "white": "#3e3e1d",
+  "brightBlack": "#443b35",
+  "brightRed": "#a61111",
+  "brightGreen": "#315c2b",
+  "brightYellow": "#7a4612",
+  "brightBlue": "#205970",
+  "brightPurple": "#6d21c9",
+  "brightCyan": "#315a4e",
+  "brightWhite": "#3e3e0d"
+}

--- a/extras/windows-terminal/themes/light/2/oasis_desert_light_2.json
+++ b/extras/windows-terminal/themes/light/2/oasis_desert_light_2.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Desert Light 2",
+  "background": "#f6f2db",
+  "foreground": "#181811",
+  "cursorColor": "#776b1d",
+  "selectionBackground": "#eae0aa",
+  "black": "#474747",
+  "red": "#bb1313",
+  "green": "#3b6837",
+  "yellow": "#655f22",
+  "blue": "#155ea9",
+  "purple": "#7c2adc",
+  "cyan": "#396659",
+  "white": "#494922",
+  "brightBlack": "#50453e",
+  "brightRed": "#bb1313",
+  "brightGreen": "#376930",
+  "brightYellow": "#8a4f14",
+  "brightBlue": "#24647e",
+  "brightPurple": "#7b2bdc",
+  "brightCyan": "#376658",
+  "brightWhite": "#4a4a10"
+}

--- a/extras/windows-terminal/themes/light/2/oasis_dune_light_2.json
+++ b/extras/windows-terminal/themes/light/2/oasis_dune_light_2.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Dune Light 2",
+  "background": "#f9f0e1",
+  "foreground": "#181811",
+  "cursorColor": "#766a1d",
+  "selectionBackground": "#efd7ae",
+  "black": "#474747",
+  "red": "#ba1313",
+  "green": "#3b6837",
+  "yellow": "#655f22",
+  "blue": "#155ea8",
+  "purple": "#7c29dc",
+  "cyan": "#396659",
+  "white": "#494922",
+  "brightBlack": "#50453e",
+  "brightRed": "#bb1313",
+  "brightGreen": "#376830",
+  "brightYellow": "#8a4f14",
+  "brightBlue": "#24647e",
+  "brightPurple": "#7b2bdc",
+  "brightCyan": "#376658",
+  "brightWhite": "#4a4a0f"
+}

--- a/extras/windows-terminal/themes/light/2/oasis_lagoon_light_2.json
+++ b/extras/windows-terminal/themes/light/2/oasis_lagoon_light_2.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Lagoon Light 2",
+  "background": "#e9f2fc",
+  "foreground": "#181811",
+  "cursorColor": "#1668cc",
+  "selectionBackground": "#b3d2f5",
+  "black": "#474747",
+  "red": "#ba1313",
+  "green": "#3b6837",
+  "yellow": "#655f22",
+  "blue": "#155ea8",
+  "purple": "#7c29dc",
+  "cyan": "#396559",
+  "white": "#494922",
+  "brightBlack": "#50453e",
+  "brightRed": "#ba1313",
+  "brightGreen": "#376830",
+  "brightYellow": "#8a4f14",
+  "brightBlue": "#24647e",
+  "brightPurple": "#7a2adc",
+  "brightCyan": "#376658",
+  "brightWhite": "#4a4a0f"
+}

--- a/extras/windows-terminal/themes/light/2/oasis_luna_light_2.json
+++ b/extras/windows-terminal/themes/light/2/oasis_luna_light_2.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Luna Light 2",
+  "background": "#eeecfb",
+  "foreground": "#181811",
+  "cursorColor": "#72692e",
+  "selectionBackground": "#c1b9f0",
+  "black": "#454545",
+  "red": "#b71212",
+  "green": "#3a6536",
+  "yellow": "#635c21",
+  "blue": "#145ca5",
+  "purple": "#7925db",
+  "cyan": "#386357",
+  "white": "#474721",
+  "brightBlack": "#4e433c",
+  "brightRed": "#b71212",
+  "brightGreen": "#36662f",
+  "brightYellow": "#874d14",
+  "brightBlue": "#23627b",
+  "brightPurple": "#7826db",
+  "brightCyan": "#366456",
+  "brightWhite": "#47470f"
+}

--- a/extras/windows-terminal/themes/light/2/oasis_midnight_light_2.json
+++ b/extras/windows-terminal/themes/light/2/oasis_midnight_light_2.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Midnight Light 2",
+  "background": "#e3e6ee",
+  "foreground": "#181811",
+  "cursorColor": "#6d642c",
+  "selectionBackground": "#bdc4d7",
+  "black": "#414141",
+  "red": "#ae1212",
+  "green": "#376033",
+  "yellow": "#5f5820",
+  "blue": "#13589d",
+  "purple": "#7323d2",
+  "cyan": "#365f53",
+  "white": "#43431f",
+  "brightBlack": "#493f39",
+  "brightRed": "#ae1212",
+  "brightGreen": "#33612d",
+  "brightYellow": "#804913",
+  "brightBlue": "#225d76",
+  "brightPurple": "#7223d3",
+  "brightCyan": "#335f52",
+  "brightWhite": "#43430e"
+}

--- a/extras/windows-terminal/themes/light/2/oasis_mirage_light_2.json
+++ b/extras/windows-terminal/themes/light/2/oasis_mirage_light_2.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Mirage Light 2",
+  "background": "#e3f6f4",
+  "foreground": "#181811",
+  "cursorColor": "#377564",
+  "selectionBackground": "#b5e7e2",
+  "black": "#484848",
+  "red": "#bc1313",
+  "green": "#3b6837",
+  "yellow": "#665f22",
+  "blue": "#155fa9",
+  "purple": "#7c2bdc",
+  "cyan": "#3a665a",
+  "white": "#4a4a22",
+  "brightBlack": "#50463e",
+  "brightRed": "#bc1313",
+  "brightGreen": "#386931",
+  "brightYellow": "#8a4f14",
+  "brightBlue": "#24657f",
+  "brightPurple": "#7b2cdc",
+  "brightCyan": "#386759",
+  "brightWhite": "#4a4a10"
+}

--- a/extras/windows-terminal/themes/light/2/oasis_moonlight_light_2.json
+++ b/extras/windows-terminal/themes/light/2/oasis_moonlight_light_2.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Moonlight Light 2",
+  "background": "#eeebe2",
+  "foreground": "#181811",
+  "cursorColor": "#70672d",
+  "selectionBackground": "#d7d0bb",
+  "black": "#444444",
+  "red": "#b41212",
+  "green": "#396435",
+  "yellow": "#615b21",
+  "blue": "#145ba2",
+  "purple": "#7724d9",
+  "cyan": "#376256",
+  "white": "#464621",
+  "brightBlack": "#4c423b",
+  "brightRed": "#b41212",
+  "brightGreen": "#35652f",
+  "brightYellow": "#854c13",
+  "brightBlue": "#23607a",
+  "brightPurple": "#7624da",
+  "brightCyan": "#356255",
+  "brightWhite": "#46460f"
+}

--- a/extras/windows-terminal/themes/light/2/oasis_night_light_2.json
+++ b/extras/windows-terminal/themes/light/2/oasis_night_light_2.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Night Light 2",
+  "background": "#e4edf7",
+  "foreground": "#181811",
+  "cursorColor": "#71672d",
+  "selectionBackground": "#b4cfe9",
+  "black": "#444444",
+  "red": "#b51212",
+  "green": "#396435",
+  "yellow": "#625c21",
+  "blue": "#145ba3",
+  "purple": "#7824da",
+  "cyan": "#386256",
+  "white": "#464621",
+  "brightBlack": "#4d423c",
+  "brightRed": "#b51212",
+  "brightGreen": "#35652f",
+  "brightYellow": "#854d14",
+  "brightBlue": "#23617a",
+  "brightPurple": "#7725db",
+  "brightCyan": "#356355",
+  "brightWhite": "#47470f"
+}

--- a/extras/windows-terminal/themes/light/2/oasis_rose_light_2.json
+++ b/extras/windows-terminal/themes/light/2/oasis_rose_light_2.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Rose Light 2",
+  "background": "#f6e2ef",
+  "foreground": "#181811",
+  "cursorColor": "#aa3c68",
+  "selectionBackground": "#e8b3d5",
+  "black": "#424242",
+  "red": "#b01212",
+  "green": "#376134",
+  "yellow": "#5f5920",
+  "blue": "#13599f",
+  "purple": "#7423d4",
+  "cyan": "#365f54",
+  "white": "#444420",
+  "brightBlack": "#4a4039",
+  "brightRed": "#b01212",
+  "brightGreen": "#34622e",
+  "brightYellow": "#824a13",
+  "brightBlue": "#225e77",
+  "brightPurple": "#7323d5",
+  "brightCyan": "#346053",
+  "brightWhite": "#44440e"
+}

--- a/extras/windows-terminal/themes/light/2/oasis_scorpion_light_2.json
+++ b/extras/windows-terminal/themes/light/2/oasis_scorpion_light_2.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Scorpion Light 2",
+  "background": "#f6d9d0",
+  "foreground": "#181811",
+  "cursorColor": "#68602a",
+  "selectionBackground": "#ecaf9d",
+  "black": "#3d3d3d",
+  "red": "#a61111",
+  "green": "#345c31",
+  "yellow": "#5a541e",
+  "blue": "#125496",
+  "purple": "#6e21c8",
+  "cyan": "#335a4f",
+  "white": "#3e3e1d",
+  "brightBlack": "#443b35",
+  "brightRed": "#a61111",
+  "brightGreen": "#315d2b",
+  "brightYellow": "#7a4612",
+  "brightBlue": "#205970",
+  "brightPurple": "#6d21c9",
+  "brightCyan": "#315a4e",
+  "brightWhite": "#3f3f0d"
+}

--- a/extras/windows-terminal/themes/light/2/oasis_sol_light_2.json
+++ b/extras/windows-terminal/themes/light/2/oasis_sol_light_2.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Sol Light 2",
+  "background": "#f5d1d1",
+  "foreground": "#181811",
+  "cursorColor": "#ae262a",
+  "selectionBackground": "#ea9f9f",
+  "black": "#393939",
+  "red": "#a01010",
+  "green": "#32582f",
+  "yellow": "#56501d",
+  "blue": "#12508f",
+  "purple": "#6a20c0",
+  "cyan": "#31564c",
+  "white": "#3b3b1b",
+  "brightBlack": "#403832",
+  "brightRed": "#a01010",
+  "brightGreen": "#2f5929",
+  "brightYellow": "#754311",
+  "brightBlue": "#1f556b",
+  "brightPurple": "#6820c1",
+  "brightCyan": "#2f574b",
+  "brightWhite": "#3b3b0c"
+}

--- a/extras/windows-terminal/themes/light/2/oasis_starlight_light_2.json
+++ b/extras/windows-terminal/themes/light/2/oasis_starlight_light_2.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Starlight Light 2",
+  "background": "#faf8f4",
+  "foreground": "#1d1d14",
+  "cursorColor": "#796f31",
+  "selectionBackground": "#e7ddca",
+  "black": "#4b4b4b",
+  "red": "#c21414",
+  "green": "#3d6c3a",
+  "yellow": "#6a6323",
+  "blue": "#1662b0",
+  "purple": "#8031dd",
+  "cyan": "#3c6a5d",
+  "white": "#4d4d24",
+  "brightBlack": "#544942",
+  "brightRed": "#c21414",
+  "brightGreen": "#3a6d33",
+  "brightYellow": "#905215",
+  "brightBlue": "#266984",
+  "brightPurple": "#7f32dd",
+  "brightCyan": "#3a6a5c",
+  "brightWhite": "#4e4e10"
+}

--- a/extras/windows-terminal/themes/light/2/oasis_twilight_light_2.json
+++ b/extras/windows-terminal/themes/light/2/oasis_twilight_light_2.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Twilight Light 2",
+  "background": "#f1eaf8",
+  "foreground": "#181811",
+  "cursorColor": "#b5401f",
+  "selectionBackground": "#d2bce9",
+  "black": "#454545",
+  "red": "#b61212",
+  "green": "#396536",
+  "yellow": "#625c21",
+  "blue": "#145ca4",
+  "purple": "#7824db",
+  "cyan": "#386357",
+  "white": "#474721",
+  "brightBlack": "#4d433c",
+  "brightRed": "#b61212",
+  "brightGreen": "#36662f",
+  "brightYellow": "#864d14",
+  "brightBlue": "#23617b",
+  "brightPurple": "#7725db",
+  "brightCyan": "#366356",
+  "brightWhite": "#47470f"
+}

--- a/extras/windows-terminal/themes/light/3/oasis_abyss_light_3.json
+++ b/extras/windows-terminal/themes/light/3/oasis_abyss_light_3.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Abyss Light 3",
+  "background": "#d8d8d8",
+  "foreground": "#181811",
+  "cursorColor": "#635c28",
+  "selectionBackground": "#b9b9b9",
+  "black": "#383838",
+  "red": "#9e1010",
+  "green": "#31572e",
+  "yellow": "#554f1c",
+  "blue": "#11508d",
+  "purple": "#691fbe",
+  "cyan": "#31554c",
+  "white": "#3a3a1b",
+  "brightBlack": "#3f3731",
+  "brightRed": "#9e1010",
+  "brightGreen": "#2f5829",
+  "brightYellow": "#744211",
+  "brightBlue": "#1e546a",
+  "brightPurple": "#671fc0",
+  "brightCyan": "#2f564a",
+  "brightWhite": "#3a3a0c"
+}

--- a/extras/windows-terminal/themes/light/3/oasis_cactus_light_3.json
+++ b/extras/windows-terminal/themes/light/3/oasis_cactus_light_3.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Cactus Light 3",
+  "background": "#dcefe3",
+  "foreground": "#181811",
+  "cursorColor": "#417144",
+  "selectionBackground": "#b2dcc1",
+  "black": "#434343",
+  "red": "#b31212",
+  "green": "#386334",
+  "yellow": "#615b20",
+  "blue": "#145ba1",
+  "purple": "#7723d8",
+  "cyan": "#376156",
+  "white": "#454520",
+  "brightBlack": "#4b423a",
+  "brightRed": "#b31212",
+  "brightGreen": "#35642e",
+  "brightYellow": "#844c14",
+  "brightBlue": "#226078",
+  "brightPurple": "#7524d9",
+  "brightCyan": "#366255",
+  "brightWhite": "#46460f"
+}

--- a/extras/windows-terminal/themes/light/3/oasis_canyon_light_3.json
+++ b/extras/windows-terminal/themes/light/3/oasis_canyon_light_3.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Canyon Light 3",
+  "background": "#eed3bd",
+  "foreground": "#181811",
+  "cursorColor": "#9f381a",
+  "selectionBackground": "#e1b38c",
+  "black": "#383838",
+  "red": "#9e1010",
+  "green": "#31572e",
+  "yellow": "#554f1c",
+  "blue": "#114f8d",
+  "purple": "#681fbe",
+  "cyan": "#31554b",
+  "white": "#3a3a1b",
+  "brightBlack": "#3e3731",
+  "brightRed": "#9e1010",
+  "brightGreen": "#2f5828",
+  "brightYellow": "#744211",
+  "brightBlue": "#1e5469",
+  "brightPurple": "#671fbf",
+  "brightCyan": "#2f564a",
+  "brightWhite": "#3a3a0c"
+}

--- a/extras/windows-terminal/themes/light/3/oasis_desert_light_3.json
+++ b/extras/windows-terminal/themes/light/3/oasis_desert_light_3.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Desert Light 3",
+  "background": "#f3edcf",
+  "foreground": "#181811",
+  "cursorColor": "#74671c",
+  "selectionBackground": "#e7db9e",
+  "black": "#444444",
+  "red": "#b61212",
+  "green": "#396535",
+  "yellow": "#635c21",
+  "blue": "#145ca2",
+  "purple": "#7824db",
+  "cyan": "#386257",
+  "white": "#464621",
+  "brightBlack": "#4c433b",
+  "brightRed": "#b61212",
+  "brightGreen": "#36652f",
+  "brightYellow": "#864d14",
+  "brightBlue": "#23617a",
+  "brightPurple": "#7725db",
+  "brightCyan": "#366356",
+  "brightWhite": "#47470f"
+}

--- a/extras/windows-terminal/themes/light/3/oasis_dune_light_3.json
+++ b/extras/windows-terminal/themes/light/3/oasis_dune_light_3.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Dune Light 3",
+  "background": "#f7e9d4",
+  "foreground": "#181811",
+  "cursorColor": "#73661c",
+  "selectionBackground": "#edcfa0",
+  "black": "#444444",
+  "red": "#b41212",
+  "green": "#386334",
+  "yellow": "#615b20",
+  "blue": "#145ba1",
+  "purple": "#7723d9",
+  "cyan": "#386156",
+  "white": "#454520",
+  "brightBlack": "#4b423b",
+  "brightRed": "#b41212",
+  "brightGreen": "#35642e",
+  "brightYellow": "#854c14",
+  "brightBlue": "#226079",
+  "brightPurple": "#7624da",
+  "brightCyan": "#366255",
+  "brightWhite": "#46460f"
+}

--- a/extras/windows-terminal/themes/light/3/oasis_lagoon_light_3.json
+++ b/extras/windows-terminal/themes/light/3/oasis_lagoon_light_3.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Lagoon Light 3",
+  "background": "#dceafa",
+  "foreground": "#181811",
+  "cursorColor": "#1563c1",
+  "selectionBackground": "#a6caf2",
+  "black": "#424242",
+  "red": "#b11212",
+  "green": "#386233",
+  "yellow": "#605920",
+  "blue": "#13599f",
+  "purple": "#7523d5",
+  "cyan": "#376055",
+  "white": "#444420",
+  "brightBlack": "#4a4139",
+  "brightRed": "#b11212",
+  "brightGreen": "#34632e",
+  "brightYellow": "#824b14",
+  "brightBlue": "#225f77",
+  "brightPurple": "#7423d7",
+  "brightCyan": "#356054",
+  "brightWhite": "#45450f"
+}

--- a/extras/windows-terminal/themes/light/3/oasis_luna_light_3.json
+++ b/extras/windows-terminal/themes/light/3/oasis_luna_light_3.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Luna Light 3",
+  "background": "#e2e0f8",
+  "foreground": "#181811",
+  "cursorColor": "#6a622a",
+  "selectionBackground": "#b3aeed",
+  "black": "#3e3e3e",
+  "red": "#aa1111",
+  "green": "#355e31",
+  "yellow": "#5c561f",
+  "blue": "#135698",
+  "purple": "#7121cd",
+  "cyan": "#355c52",
+  "white": "#40401e",
+  "brightBlack": "#463d36",
+  "brightRed": "#aa1111",
+  "brightGreen": "#325f2c",
+  "brightYellow": "#7d4813",
+  "brightBlue": "#205b72",
+  "brightPurple": "#6f22ce",
+  "brightCyan": "#335c50",
+  "brightWhite": "#41410e"
+}

--- a/extras/windows-terminal/themes/light/3/oasis_midnight_light_3.json
+++ b/extras/windows-terminal/themes/light/3/oasis_midnight_light_3.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Midnight Light 3",
+  "background": "#d9dee8",
+  "foreground": "#181811",
+  "cursorColor": "#675f29",
+  "selectionBackground": "#b3bdd1",
+  "black": "#3c3c3c",
+  "red": "#a51111",
+  "green": "#345b30",
+  "yellow": "#59531e",
+  "blue": "#125393",
+  "purple": "#6d20c7",
+  "cyan": "#33594f",
+  "white": "#3e3e1d",
+  "brightBlack": "#433a34",
+  "brightRed": "#a51111",
+  "brightGreen": "#315c2a",
+  "brightYellow": "#794512",
+  "brightBlue": "#1f586e",
+  "brightPurple": "#6c21c8",
+  "brightCyan": "#31594e",
+  "brightWhite": "#3e3e0d"
+}

--- a/extras/windows-terminal/themes/light/3/oasis_mirage_light_3.json
+++ b/extras/windows-terminal/themes/light/3/oasis_mirage_light_3.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Mirage Light 3",
+  "background": "#d8f2ef",
+  "foreground": "#181811",
+  "cursorColor": "#367261",
+  "selectionBackground": "#aae3dc",
+  "black": "#454545",
+  "red": "#b61212",
+  "green": "#396535",
+  "yellow": "#635c21",
+  "blue": "#145ca3",
+  "purple": "#7824db",
+  "cyan": "#386357",
+  "white": "#464621",
+  "brightBlack": "#4c433b",
+  "brightRed": "#b61212",
+  "brightGreen": "#36652f",
+  "brightYellow": "#864d14",
+  "brightBlue": "#23617a",
+  "brightPurple": "#7725db",
+  "brightCyan": "#366356",
+  "brightWhite": "#47470f"
+}

--- a/extras/windows-terminal/themes/light/3/oasis_moonlight_light_3.json
+++ b/extras/windows-terminal/themes/light/3/oasis_moonlight_light_3.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Moonlight Light 3",
+  "background": "#e8e5d8",
+  "foreground": "#181811",
+  "cursorColor": "#6b632b",
+  "selectionBackground": "#d1cbb2",
+  "black": "#404040",
+  "red": "#ad1111",
+  "green": "#366032",
+  "yellow": "#5e571f",
+  "blue": "#13579b",
+  "purple": "#7322d1",
+  "cyan": "#365e53",
+  "white": "#42421f",
+  "brightBlack": "#483f38",
+  "brightRed": "#ad1111",
+  "brightGreen": "#33602c",
+  "brightYellow": "#7f4913",
+  "brightBlue": "#215d74",
+  "brightPurple": "#7122d2",
+  "brightCyan": "#345e52",
+  "brightWhite": "#42420e"
+}

--- a/extras/windows-terminal/themes/light/3/oasis_night_light_3.json
+++ b/extras/windows-terminal/themes/light/3/oasis_night_light_3.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Night Light 3",
+  "background": "#d1e2f5",
+  "foreground": "#181811",
+  "cursorColor": "#68602a",
+  "selectionBackground": "#9ec2eb",
+  "black": "#3d3d3d",
+  "red": "#a81111",
+  "green": "#355d31",
+  "yellow": "#5b551e",
+  "blue": "#125496",
+  "purple": "#6f21ca",
+  "cyan": "#345b50",
+  "white": "#3f3f1e",
+  "brightBlack": "#443c35",
+  "brightRed": "#a81111",
+  "brightGreen": "#325d2b",
+  "brightYellow": "#7b4613",
+  "brightBlue": "#205a70",
+  "brightPurple": "#6e21cb",
+  "brightCyan": "#325b4f",
+  "brightWhite": "#3f3f0e"
+}

--- a/extras/windows-terminal/themes/light/3/oasis_rose_light_3.json
+++ b/extras/windows-terminal/themes/light/3/oasis_rose_light_3.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Rose Light 3",
+  "background": "#f3d6e8",
+  "foreground": "#181811",
+  "cursorColor": "#9f3a62",
+  "selectionBackground": "#e5a7cd",
+  "black": "#3c3c3c",
+  "red": "#a51111",
+  "green": "#345b30",
+  "yellow": "#59531e",
+  "blue": "#125393",
+  "purple": "#6d20c7",
+  "cyan": "#33594f",
+  "white": "#3e3e1d",
+  "brightBlack": "#433a34",
+  "brightRed": "#a51111",
+  "brightGreen": "#315c2a",
+  "brightYellow": "#794512",
+  "brightBlue": "#1f586f",
+  "brightPurple": "#6c21c8",
+  "brightCyan": "#31594e",
+  "brightWhite": "#3e3e0d"
+}

--- a/extras/windows-terminal/themes/light/3/oasis_scorpion_light_3.json
+++ b/extras/windows-terminal/themes/light/3/oasis_scorpion_light_3.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Scorpion Light 3",
+  "background": "#f4cfc3",
+  "foreground": "#181811",
+  "cursorColor": "#625b27",
+  "selectionBackground": "#eba68f",
+  "black": "#373737",
+  "red": "#9d1010",
+  "green": "#31562d",
+  "yellow": "#554f1c",
+  "blue": "#114f8b",
+  "purple": "#681fbd",
+  "cyan": "#30554b",
+  "white": "#39391b",
+  "brightBlack": "#3e3630",
+  "brightRed": "#9d1010",
+  "brightGreen": "#2e5728",
+  "brightYellow": "#734211",
+  "brightBlue": "#1e5469",
+  "brightPurple": "#661fbe",
+  "brightCyan": "#2e554a",
+  "brightWhite": "#39390c"
+}

--- a/extras/windows-terminal/themes/light/3/oasis_sol_light_3.json
+++ b/extras/windows-terminal/themes/light/3/oasis_sol_light_3.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Sol Light 3",
+  "background": "#f2c4c4",
+  "foreground": "#181811",
+  "cursorColor": "#a22327",
+  "selectionBackground": "#e79292",
+  "black": "#323232",
+  "red": "#930f0f",
+  "green": "#2e512a",
+  "yellow": "#4f4a1a",
+  "blue": "#104a83",
+  "purple": "#611db1",
+  "cyan": "#2d4f46",
+  "white": "#343418",
+  "brightBlack": "#38312c",
+  "brightRed": "#930f0f",
+  "brightGreen": "#2b5126",
+  "brightYellow": "#6b3e10",
+  "brightBlue": "#1c4e62",
+  "brightPurple": "#601db2",
+  "brightCyan": "#2b4f45",
+  "brightWhite": "#34340b"
+}

--- a/extras/windows-terminal/themes/light/3/oasis_starlight_light_3.json
+++ b/extras/windows-terminal/themes/light/3/oasis_starlight_light_3.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Starlight Light 3",
+  "background": "#f5f2ea",
+  "foreground": "#181811",
+  "cursorColor": "#746b2e",
+  "selectionBackground": "#e1d8c1",
+  "black": "#484848",
+  "red": "#bc1313",
+  "green": "#3b6837",
+  "yellow": "#665f22",
+  "blue": "#155fa8",
+  "purple": "#7d2adc",
+  "cyan": "#3a665a",
+  "white": "#4a4a23",
+  "brightBlack": "#50463e",
+  "brightRed": "#bc1313",
+  "brightGreen": "#386930",
+  "brightYellow": "#8b4f15",
+  "brightBlue": "#24657f",
+  "brightPurple": "#7b2bdc",
+  "brightCyan": "#386659",
+  "brightWhite": "#4a4a10"
+}

--- a/extras/windows-terminal/themes/light/3/oasis_twilight_light_3.json
+++ b/extras/windows-terminal/themes/light/3/oasis_twilight_light_3.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Twilight Light 3",
+  "background": "#eadff4",
+  "foreground": "#181811",
+  "cursorColor": "#ab3d1c",
+  "selectionBackground": "#ccb1e4",
+  "black": "#3f3f3f",
+  "red": "#ab1111",
+  "green": "#365f32",
+  "yellow": "#5d561f",
+  "blue": "#135699",
+  "purple": "#7121ce",
+  "cyan": "#355d52",
+  "white": "#41411e",
+  "brightBlack": "#463d37",
+  "brightRed": "#ab1111",
+  "brightGreen": "#335f2c",
+  "brightYellow": "#7e4813",
+  "brightBlue": "#215b73",
+  "brightPurple": "#7022d0",
+  "brightCyan": "#335d51",
+  "brightWhite": "#41410e"
+}

--- a/extras/windows-terminal/themes/light/4/oasis_abyss_light_4.json
+++ b/extras/windows-terminal/themes/light/4/oasis_abyss_light_4.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Abyss Light 4",
+  "background": "#d0d0d0",
+  "foreground": "#181811",
+  "cursorColor": "#5e5625",
+  "selectionBackground": "#b1b1b1",
+  "black": "#333333",
+  "red": "#950f0f",
+  "green": "#2e522b",
+  "yellow": "#504a1b",
+  "blue": "#104a84",
+  "purple": "#621db2",
+  "cyan": "#2d5046",
+  "white": "#343419",
+  "brightBlack": "#39322c",
+  "brightRed": "#950e0e",
+  "brightGreen": "#2b5226",
+  "brightYellow": "#6d3e10",
+  "brightBlue": "#1c4f63",
+  "brightPurple": "#611db4",
+  "brightCyan": "#2b5046",
+  "brightWhite": "#35350b"
+}

--- a/extras/windows-terminal/themes/light/4/oasis_cactus_light_4.json
+++ b/extras/windows-terminal/themes/light/4/oasis_cactus_light_4.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Cactus Light 4",
+  "background": "#d2eadb",
+  "foreground": "#181811",
+  "cursorColor": "#406c42",
+  "selectionBackground": "#a8d7ba",
+  "black": "#404040",
+  "red": "#ac1111",
+  "green": "#365f33",
+  "yellow": "#5d571f",
+  "blue": "#13579a",
+  "purple": "#7222cf",
+  "cyan": "#355d52",
+  "white": "#41411f",
+  "brightBlack": "#473e38",
+  "brightRed": "#ac1111",
+  "brightGreen": "#33602c",
+  "brightYellow": "#7f4813",
+  "brightBlue": "#215c74",
+  "brightPurple": "#7122d1",
+  "brightCyan": "#335e51",
+  "brightWhite": "#42420e"
+}

--- a/extras/windows-terminal/themes/light/4/oasis_canyon_light_4.json
+++ b/extras/windows-terminal/themes/light/4/oasis_canyon_light_4.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Canyon Light 4",
+  "background": "#ebcbb1",
+  "foreground": "#181811",
+  "cursorColor": "#97361a",
+  "selectionBackground": "#dfab80",
+  "black": "#333333",
+  "red": "#960f0f",
+  "green": "#2e522c",
+  "yellow": "#504b1b",
+  "blue": "#104b85",
+  "purple": "#631eb3",
+  "cyan": "#2d5146",
+  "white": "#353519",
+  "brightBlack": "#39322d",
+  "brightRed": "#960f0f",
+  "brightGreen": "#2c5326",
+  "brightYellow": "#6e3f10",
+  "brightBlue": "#1c4f64",
+  "brightPurple": "#621db5",
+  "brightCyan": "#2c5146",
+  "brightWhite": "#35350b"
+}

--- a/extras/windows-terminal/themes/light/4/oasis_desert_light_4.json
+++ b/extras/windows-terminal/themes/light/4/oasis_desert_light_4.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Desert Light 4",
+  "background": "#f0e8c3",
+  "foreground": "#181811",
+  "cursorColor": "#70651b",
+  "selectionBackground": "#e4d592",
+  "black": "#424242",
+  "red": "#b01212",
+  "green": "#376134",
+  "yellow": "#5f5920",
+  "blue": "#13599d",
+  "purple": "#7523d4",
+  "cyan": "#365f53",
+  "white": "#434320",
+  "brightBlack": "#494039",
+  "brightRed": "#b01111",
+  "brightGreen": "#34622d",
+  "brightYellow": "#824a13",
+  "brightBlue": "#225e77",
+  "brightPurple": "#7322d6",
+  "brightCyan": "#346053",
+  "brightWhite": "#44440e"
+}

--- a/extras/windows-terminal/themes/light/4/oasis_dune_light_4.json
+++ b/extras/windows-terminal/themes/light/4/oasis_dune_light_4.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Dune Light 4",
+  "background": "#f5e2c7",
+  "foreground": "#181811",
+  "cursorColor": "#6e631b",
+  "selectionBackground": "#ecc793",
+  "black": "#404040",
+  "red": "#ad1212",
+  "green": "#366033",
+  "yellow": "#5e571f",
+  "blue": "#13579a",
+  "purple": "#7222d0",
+  "cyan": "#355e52",
+  "white": "#42421f",
+  "brightBlack": "#473e38",
+  "brightRed": "#ad1111",
+  "brightGreen": "#33602c",
+  "brightYellow": "#7f4913",
+  "brightBlue": "#215c74",
+  "brightPurple": "#7122d2",
+  "brightCyan": "#335e52",
+  "brightWhite": "#42420e"
+}

--- a/extras/windows-terminal/themes/light/4/oasis_lagoon_light_4.json
+++ b/extras/windows-terminal/themes/light/4/oasis_lagoon_light_4.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Lagoon Light 4",
+  "background": "#cfe2f8",
+  "foreground": "#181811",
+  "cursorColor": "#145eb7",
+  "selectionBackground": "#9ac2f0",
+  "black": "#3d3d3d",
+  "red": "#a81111",
+  "green": "#345c31",
+  "yellow": "#5a541e",
+  "blue": "#125496",
+  "purple": "#6f21c9",
+  "cyan": "#335b4f",
+  "white": "#3f3f1e",
+  "brightBlack": "#443c35",
+  "brightRed": "#a71010",
+  "brightGreen": "#315d2b",
+  "brightYellow": "#7b4612",
+  "brightBlue": "#205970",
+  "brightPurple": "#6e21cb",
+  "brightCyan": "#315b4f",
+  "brightWhite": "#3f3f0d"
+}

--- a/extras/windows-terminal/themes/light/4/oasis_luna_light_4.json
+++ b/extras/windows-terminal/themes/light/4/oasis_luna_light_4.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Luna Light 4",
+  "background": "#d6d4f5",
+  "foreground": "#181811",
+  "cursorColor": "#635b27",
+  "selectionBackground": "#a7a2e9",
+  "black": "#373737",
+  "red": "#9d1010",
+  "green": "#31562e",
+  "yellow": "#554f1c",
+  "blue": "#114f8c",
+  "purple": "#681fbd",
+  "cyan": "#30554a",
+  "white": "#39391b",
+  "brightBlack": "#3e3630",
+  "brightRed": "#9d0f0f",
+  "brightGreen": "#2e5728",
+  "brightYellow": "#734211",
+  "brightBlue": "#1e5469",
+  "brightPurple": "#671fbf",
+  "brightCyan": "#2e554a",
+  "brightWhite": "#3a3a0c"
+}

--- a/extras/windows-terminal/themes/light/4/oasis_midnight_light_4.json
+++ b/extras/windows-terminal/themes/light/4/oasis_midnight_light_4.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Midnight Light 4",
+  "background": "#cfd6e2",
+  "foreground": "#181811",
+  "cursorColor": "#625a27",
+  "selectionBackground": "#a9b5cb",
+  "black": "#373737",
+  "red": "#9b1010",
+  "green": "#30552d",
+  "yellow": "#534e1c",
+  "blue": "#114e8a",
+  "purple": "#661fba",
+  "cyan": "#2f5449",
+  "white": "#38381a",
+  "brightBlack": "#3d3530",
+  "brightRed": "#9b0f0f",
+  "brightGreen": "#2d5628",
+  "brightYellow": "#724111",
+  "brightBlue": "#1d5368",
+  "brightPurple": "#661ebc",
+  "brightCyan": "#2d5449",
+  "brightWhite": "#38380c"
+}

--- a/extras/windows-terminal/themes/light/4/oasis_mirage_light_4.json
+++ b/extras/windows-terminal/themes/light/4/oasis_mirage_light_4.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Mirage Light 4",
+  "background": "#cdeeea",
+  "foreground": "#181811",
+  "cursorColor": "#356e5e",
+  "selectionBackground": "#9fded7",
+  "black": "#424242",
+  "red": "#b01212",
+  "green": "#376134",
+  "yellow": "#5f5920",
+  "blue": "#13599d",
+  "purple": "#7423d3",
+  "cyan": "#365f53",
+  "white": "#434320",
+  "brightBlack": "#494039",
+  "brightRed": "#b01111",
+  "brightGreen": "#34622d",
+  "brightYellow": "#814a13",
+  "brightBlue": "#215e76",
+  "brightPurple": "#7322d5",
+  "brightCyan": "#346053",
+  "brightWhite": "#44440e"
+}

--- a/extras/windows-terminal/themes/light/4/oasis_moonlight_light_4.json
+++ b/extras/windows-terminal/themes/light/4/oasis_moonlight_light_4.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Moonlight Light 4",
+  "background": "#e2dfce",
+  "foreground": "#181811",
+  "cursorColor": "#685f29",
+  "selectionBackground": "#cbc6a8",
+  "black": "#3c3c3c",
+  "red": "#a61111",
+  "green": "#345c31",
+  "yellow": "#5a541e",
+  "blue": "#125394",
+  "purple": "#6e21c7",
+  "cyan": "#335a4f",
+  "white": "#3e3e1d",
+  "brightBlack": "#433b35",
+  "brightRed": "#a61010",
+  "brightGreen": "#315c2a",
+  "brightYellow": "#7a4612",
+  "brightBlue": "#20596f",
+  "brightPurple": "#6d20c9",
+  "brightCyan": "#315a4e",
+  "brightWhite": "#3e3e0d"
+}

--- a/extras/windows-terminal/themes/light/4/oasis_night_light_4.json
+++ b/extras/windows-terminal/themes/light/4/oasis_night_light_4.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Night Light 4",
+  "background": "#c1daf6",
+  "foreground": "#181811",
+  "cursorColor": "#635b27",
+  "selectionBackground": "#8cbbee",
+  "black": "#383838",
+  "red": "#9d1010",
+  "green": "#31572e",
+  "yellow": "#554f1c",
+  "blue": "#114f8c",
+  "purple": "#681fbd",
+  "cyan": "#30554a",
+  "white": "#39391b",
+  "brightBlack": "#3e3631",
+  "brightRed": "#9d0f0f",
+  "brightGreen": "#2e5728",
+  "brightYellow": "#734211",
+  "brightBlue": "#1e5469",
+  "brightPurple": "#671fbf",
+  "brightCyan": "#2e554a",
+  "brightWhite": "#3a3a0c"
+}

--- a/extras/windows-terminal/themes/light/4/oasis_rose_light_4.json
+++ b/extras/windows-terminal/themes/light/4/oasis_rose_light_4.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Rose Light 4",
+  "background": "#f0cae1",
+  "foreground": "#181811",
+  "cursorColor": "#96365c",
+  "selectionBackground": "#e39ac6",
+  "black": "#363636",
+  "red": "#9a1010",
+  "green": "#30552d",
+  "yellow": "#534d1c",
+  "blue": "#114d89",
+  "purple": "#661fb9",
+  "cyan": "#2f5349",
+  "white": "#37371a",
+  "brightBlack": "#3c352f",
+  "brightRed": "#9a0f0f",
+  "brightGreen": "#2d5527",
+  "brightYellow": "#714111",
+  "brightBlue": "#1d5267",
+  "brightPurple": "#651ebb",
+  "brightCyan": "#2d5348",
+  "brightWhite": "#38380c"
+}

--- a/extras/windows-terminal/themes/light/4/oasis_scorpion_light_4.json
+++ b/extras/windows-terminal/themes/light/4/oasis_scorpion_light_4.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Scorpion Light 4",
+  "background": "#f2c5b6",
+  "foreground": "#181811",
+  "cursorColor": "#5d5525",
+  "selectionBackground": "#e99c82",
+  "black": "#323232",
+  "red": "#930f0f",
+  "green": "#2e512b",
+  "yellow": "#4f4a1a",
+  "blue": "#104a83",
+  "purple": "#611db0",
+  "cyan": "#2d4f45",
+  "white": "#333318",
+  "brightBlack": "#38312c",
+  "brightRed": "#930e0e",
+  "brightGreen": "#2b5125",
+  "brightYellow": "#6c3e10",
+  "brightBlue": "#1c4e62",
+  "brightPurple": "#601db2",
+  "brightCyan": "#2b4f45",
+  "brightWhite": "#34340b"
+}

--- a/extras/windows-terminal/themes/light/4/oasis_sol_light_4.json
+++ b/extras/windows-terminal/themes/light/4/oasis_sol_light_4.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Sol Light 4",
+  "background": "#efb7b7",
+  "foreground": "#181811",
+  "cursorColor": "#962024",
+  "selectionBackground": "#e48585",
+  "black": "#2b2b2b",
+  "red": "#870e0e",
+  "green": "#2a4a27",
+  "yellow": "#484318",
+  "blue": "#0f4377",
+  "purple": "#591ba1",
+  "cyan": "#29483f",
+  "white": "#2c2c15",
+  "brightBlack": "#302a25",
+  "brightRed": "#870d0d",
+  "brightGreen": "#274a22",
+  "brightYellow": "#62380f",
+  "brightBlue": "#19475a",
+  "brightPurple": "#581aa3",
+  "brightCyan": "#27483f",
+  "brightWhite": "#2c2c09"
+}

--- a/extras/windows-terminal/themes/light/4/oasis_starlight_light_4.json
+++ b/extras/windows-terminal/themes/light/4/oasis_starlight_light_4.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Starlight Light 4",
+  "background": "#f0ece0",
+  "foreground": "#181811",
+  "cursorColor": "#71682d",
+  "selectionBackground": "#dcd3b7",
+  "black": "#444444",
+  "red": "#b51212",
+  "green": "#396435",
+  "yellow": "#625c21",
+  "blue": "#145ba2",
+  "purple": "#7824da",
+  "cyan": "#376256",
+  "white": "#464621",
+  "brightBlack": "#4c423c",
+  "brightRed": "#b51212",
+  "brightGreen": "#35652f",
+  "brightYellow": "#864c14",
+  "brightBlue": "#23617a",
+  "brightPurple": "#7724dc",
+  "brightCyan": "#356356",
+  "brightWhite": "#47470f"
+}

--- a/extras/windows-terminal/themes/light/4/oasis_twilight_light_4.json
+++ b/extras/windows-terminal/themes/light/4/oasis_twilight_light_4.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Twilight Light 4",
+  "background": "#e3d4f0",
+  "foreground": "#181811",
+  "cursorColor": "#a0391c",
+  "selectionBackground": "#c5a7e0",
+  "black": "#393939",
+  "red": "#a01010",
+  "green": "#32582f",
+  "yellow": "#56511d",
+  "blue": "#11508f",
+  "purple": "#6a20c0",
+  "cyan": "#31564c",
+  "white": "#3b3b1c",
+  "brightBlack": "#403832",
+  "brightRed": "#a01010",
+  "brightGreen": "#2f5929",
+  "brightYellow": "#764311",
+  "brightBlue": "#1e556b",
+  "brightPurple": "#691fc2",
+  "brightCyan": "#2f574b",
+  "brightWhite": "#3b3b0c"
+}

--- a/extras/windows-terminal/themes/light/5/oasis_abyss_light_5.json
+++ b/extras/windows-terminal/themes/light/5/oasis_abyss_light_5.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Abyss Light 5",
+  "background": "#c9c9c9",
+  "foreground": "#181811",
+  "cursorColor": "#595223",
+  "selectionBackground": "#aaaaaa",
+  "black": "#2e2e2e",
+  "red": "#8c0e0e",
+  "green": "#2b4d28",
+  "yellow": "#4b4619",
+  "blue": "#0f467c",
+  "purple": "#5d1ba8",
+  "cyan": "#2a4b42",
+  "white": "#2f2f16",
+  "brightBlack": "#332d28",
+  "brightRed": "#8c0e0e",
+  "brightGreen": "#294d24",
+  "brightYellow": "#663a0f",
+  "brightBlue": "#1b4a5d",
+  "brightPurple": "#5c1ca9",
+  "brightCyan": "#294b41",
+  "brightWhite": "#30300a"
+}

--- a/extras/windows-terminal/themes/light/5/oasis_cactus_light_5.json
+++ b/extras/windows-terminal/themes/light/5/oasis_cactus_light_5.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Cactus Light 5",
+  "background": "#c7e5d2",
+  "foreground": "#181811",
+  "cursorColor": "#3d683f",
+  "selectionBackground": "#9dd2b0",
+  "black": "#3c3c3c",
+  "red": "#a51010",
+  "green": "#335b30",
+  "yellow": "#59531d",
+  "blue": "#125393",
+  "purple": "#6d20c7",
+  "cyan": "#32594e",
+  "white": "#3d3d1d",
+  "brightBlack": "#423b33",
+  "brightRed": "#a51010",
+  "brightGreen": "#305c2b",
+  "brightYellow": "#794512",
+  "brightBlue": "#20586f",
+  "brightPurple": "#6c21c7",
+  "brightCyan": "#315a4e",
+  "brightWhite": "#3e3e0d"
+}

--- a/extras/windows-terminal/themes/light/5/oasis_canyon_light_5.json
+++ b/extras/windows-terminal/themes/light/5/oasis_canyon_light_5.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Canyon Light 5",
+  "background": "#e8c3a5",
+  "foreground": "#181811",
+  "cursorColor": "#8f3318",
+  "selectionBackground": "#dca374",
+  "black": "#2e2e2e",
+  "red": "#8d0e0e",
+  "green": "#2c4d29",
+  "yellow": "#4b4619",
+  "blue": "#0f467d",
+  "purple": "#5d1ca9",
+  "cyan": "#2b4c42",
+  "white": "#303017",
+  "brightBlack": "#342e28",
+  "brightRed": "#8d0e0e",
+  "brightGreen": "#294e24",
+  "brightYellow": "#673b0f",
+  "brightBlue": "#1b4b5e",
+  "brightPurple": "#5c1caa",
+  "brightCyan": "#2a4c42",
+  "brightWhite": "#30300a"
+}

--- a/extras/windows-terminal/themes/light/5/oasis_desert_light_5.json
+++ b/extras/windows-terminal/themes/light/5/oasis_desert_light_5.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Desert Light 5",
+  "background": "#ede4b7",
+  "foreground": "#181811",
+  "cursorColor": "#6c621a",
+  "selectionBackground": "#e1d286",
+  "black": "#3f3f3f",
+  "red": "#ab1111",
+  "green": "#365f32",
+  "yellow": "#5c561f",
+  "blue": "#135699",
+  "purple": "#7122ce",
+  "cyan": "#345d51",
+  "white": "#41411f",
+  "brightBlack": "#463e36",
+  "brightRed": "#ab1111",
+  "brightGreen": "#325f2c",
+  "brightYellow": "#7e4812",
+  "brightBlue": "#215b73",
+  "brightPurple": "#7122cf",
+  "brightCyan": "#335d51",
+  "brightWhite": "#41410e"
+}

--- a/extras/windows-terminal/themes/light/5/oasis_dune_light_5.json
+++ b/extras/windows-terminal/themes/light/5/oasis_dune_light_5.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Dune Light 5",
+  "background": "#f2dcba",
+  "foreground": "#181811",
+  "cursorColor": "#695f1a",
+  "selectionBackground": "#e8c287",
+  "black": "#3d3d3d",
+  "red": "#a61010",
+  "green": "#345c30",
+  "yellow": "#5a541e",
+  "blue": "#125495",
+  "purple": "#6e21c8",
+  "cyan": "#335a4f",
+  "white": "#3e3e1d",
+  "brightBlack": "#433b34",
+  "brightRed": "#a61010",
+  "brightGreen": "#315c2b",
+  "brightYellow": "#7a4612",
+  "brightBlue": "#205970",
+  "brightPurple": "#6d21c9",
+  "brightCyan": "#315a4e",
+  "brightWhite": "#3f3f0d"
+}

--- a/extras/windows-terminal/themes/light/5/oasis_lagoon_light_5.json
+++ b/extras/windows-terminal/themes/light/5/oasis_lagoon_light_5.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Lagoon Light 5",
+  "background": "#c1daf6",
+  "foreground": "#181811",
+  "cursorColor": "#1358ae",
+  "selectionBackground": "#8cbaee",
+  "black": "#383838",
+  "red": "#9e0f0f",
+  "green": "#31572e",
+  "yellow": "#554f1c",
+  "blue": "#114f8c",
+  "purple": "#681fbd",
+  "cyan": "#30554a",
+  "white": "#39391b",
+  "brightBlack": "#3e3630",
+  "brightRed": "#9d0f0f",
+  "brightGreen": "#2e5729",
+  "brightYellow": "#734211",
+  "brightBlue": "#1e546a",
+  "brightPurple": "#671fbe",
+  "brightCyan": "#2f554a",
+  "brightWhite": "#3a3a0c"
+}

--- a/extras/windows-terminal/themes/light/5/oasis_luna_light_5.json
+++ b/extras/windows-terminal/themes/light/5/oasis_luna_light_5.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Luna Light 5",
+  "background": "#cbc7f2",
+  "foreground": "#181811",
+  "cursorColor": "#5a5324",
+  "selectionBackground": "#9d95e6",
+  "black": "#303030",
+  "red": "#8f0e0e",
+  "green": "#2c4e29",
+  "yellow": "#4c4819",
+  "blue": "#0f487f",
+  "purple": "#5e1cac",
+  "cyan": "#2b4d43",
+  "white": "#313117",
+  "brightBlack": "#352f29",
+  "brightRed": "#8f0e0e",
+  "brightGreen": "#2a4f25",
+  "brightYellow": "#683c0f",
+  "brightBlue": "#1b4c5f",
+  "brightPurple": "#5e1cac",
+  "brightCyan": "#2a4d43",
+  "brightWhite": "#31310a"
+}

--- a/extras/windows-terminal/themes/light/5/oasis_midnight_light_5.json
+++ b/extras/windows-terminal/themes/light/5/oasis_midnight_light_5.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Midnight Light 5",
+  "background": "#c6cddc",
+  "foreground": "#181811",
+  "cursorColor": "#5b5424",
+  "selectionBackground": "#a0acc5",
+  "black": "#313131",
+  "red": "#910e0e",
+  "green": "#2d4f2a",
+  "yellow": "#4d481a",
+  "blue": "#104880",
+  "purple": "#601cae",
+  "cyan": "#2c4e44",
+  "white": "#323218",
+  "brightBlack": "#362f2a",
+  "brightRed": "#910e0e",
+  "brightGreen": "#2a5025",
+  "brightYellow": "#6a3c0f",
+  "brightBlue": "#1c4d61",
+  "brightPurple": "#5f1dae",
+  "brightCyan": "#2b4e44",
+  "brightWhite": "#32320b"
+}

--- a/extras/windows-terminal/themes/light/5/oasis_mirage_light_5.json
+++ b/extras/windows-terminal/themes/light/5/oasis_mirage_light_5.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Mirage Light 5",
+  "background": "#c1eae6",
+  "foreground": "#181811",
+  "cursorColor": "#316b5a",
+  "selectionBackground": "#93dbd4",
+  "black": "#3e3e3e",
+  "red": "#aa1010",
+  "green": "#355e31",
+  "yellow": "#5c561e",
+  "blue": "#125598",
+  "purple": "#7021cc",
+  "cyan": "#345c50",
+  "white": "#40401e",
+  "brightBlack": "#453d36",
+  "brightRed": "#aa1111",
+  "brightGreen": "#325f2c",
+  "brightYellow": "#7d4712",
+  "brightBlue": "#215a72",
+  "brightPurple": "#6f22cd",
+  "brightCyan": "#325c50",
+  "brightWhite": "#40400e"
+}

--- a/extras/windows-terminal/themes/light/5/oasis_moonlight_light_5.json
+++ b/extras/windows-terminal/themes/light/5/oasis_moonlight_light_5.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Moonlight Light 5",
+  "background": "#ddd8c5",
+  "foreground": "#181811",
+  "cursorColor": "#635b28",
+  "selectionBackground": "#c6be9e",
+  "black": "#383838",
+  "red": "#9e0f0f",
+  "green": "#31572e",
+  "yellow": "#55501c",
+  "blue": "#114f8d",
+  "purple": "#691fbe",
+  "cyan": "#30554b",
+  "white": "#3a3a1b",
+  "brightBlack": "#3e3730",
+  "brightRed": "#9e0f0f",
+  "brightGreen": "#2e5829",
+  "brightYellow": "#744211",
+  "brightBlue": "#1e546a",
+  "brightPurple": "#681fbf",
+  "brightCyan": "#2f564a",
+  "brightWhite": "#3a3a0c"
+}

--- a/extras/windows-terminal/themes/light/5/oasis_night_light_5.json
+++ b/extras/windows-terminal/themes/light/5/oasis_night_light_5.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Night Light 5",
+  "background": "#b7d5f0",
+  "foreground": "#181811",
+  "cursorColor": "#5e5726",
+  "selectionBackground": "#84b7e6",
+  "black": "#343434",
+  "red": "#960f0f",
+  "green": "#2f522b",
+  "yellow": "#504b1b",
+  "blue": "#104b86",
+  "purple": "#631db5",
+  "cyan": "#2d5147",
+  "white": "#353519",
+  "brightBlack": "#3a332d",
+  "brightRed": "#970f0f",
+  "brightGreen": "#2c5327",
+  "brightYellow": "#6e3f10",
+  "brightBlue": "#1d5064",
+  "brightPurple": "#621eb5",
+  "brightCyan": "#2c5146",
+  "brightWhite": "#36360b"
+}

--- a/extras/windows-terminal/themes/light/5/oasis_rose_light_5.json
+++ b/extras/windows-terminal/themes/light/5/oasis_rose_light_5.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Rose Light 5",
+  "background": "#ecbedb",
+  "foreground": "#181811",
+  "cursorColor": "#8c3156",
+  "selectionBackground": "#de8fc1",
+  "black": "#303030",
+  "red": "#8f0e0e",
+  "green": "#2c4e29",
+  "yellow": "#4c4719",
+  "blue": "#0f477f",
+  "purple": "#5e1cab",
+  "cyan": "#2b4d43",
+  "white": "#313117",
+  "brightBlack": "#352e29",
+  "brightRed": "#8f0e0e",
+  "brightGreen": "#2a4f25",
+  "brightYellow": "#683b0f",
+  "brightBlue": "#1b4b5f",
+  "brightPurple": "#5d1cac",
+  "brightCyan": "#2a4d43",
+  "brightWhite": "#31310a"
+}

--- a/extras/windows-terminal/themes/light/5/oasis_scorpion_light_5.json
+++ b/extras/windows-terminal/themes/light/5/oasis_scorpion_light_5.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Scorpion Light 5",
+  "background": "#efbaa9",
+  "foreground": "#181811",
+  "cursorColor": "#564f22",
+  "selectionBackground": "#e59175",
+  "black": "#2c2c2c",
+  "red": "#880d0d",
+  "green": "#2a4a27",
+  "yellow": "#484418",
+  "blue": "#0f4478",
+  "purple": "#5a1ba3",
+  "cyan": "#29493f",
+  "white": "#2d2d15",
+  "brightBlack": "#302b25",
+  "brightRed": "#880d0d",
+  "brightGreen": "#284b23",
+  "brightYellow": "#63390f",
+  "brightBlue": "#1a485b",
+  "brightPurple": "#591ba4",
+  "brightCyan": "#28493f",
+  "brightWhite": "#2d2d0a"
+}

--- a/extras/windows-terminal/themes/light/5/oasis_sol_light_5.json
+++ b/extras/windows-terminal/themes/light/5/oasis_sol_light_5.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Sol Light 5",
+  "background": "#ecabab",
+  "foreground": "#181811",
+  "cursorColor": "#891f21",
+  "selectionBackground": "#e17979",
+  "black": "#232323",
+  "red": "#7b0c0c",
+  "green": "#254223",
+  "yellow": "#413c15",
+  "blue": "#0d3d6c",
+  "purple": "#511893",
+  "cyan": "#254139",
+  "white": "#242411",
+  "brightBlack": "#27221e",
+  "brightRed": "#7b0c0c",
+  "brightGreen": "#23431f",
+  "brightYellow": "#59330d",
+  "brightBlue": "#174051",
+  "brightPurple": "#501893",
+  "brightCyan": "#244139",
+  "brightWhite": "#252508"
+}

--- a/extras/windows-terminal/themes/light/5/oasis_starlight_light_5.json
+++ b/extras/windows-terminal/themes/light/5/oasis_starlight_light_5.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Starlight Light 5",
+  "background": "#ebe5d5",
+  "foreground": "#181811",
+  "cursorColor": "#6c642b",
+  "selectionBackground": "#d7cbac",
+  "black": "#404040",
+  "red": "#ae1111",
+  "green": "#366033",
+  "yellow": "#5e581f",
+  "blue": "#13579b",
+  "purple": "#7322d1",
+  "cyan": "#355e52",
+  "white": "#42421f",
+  "brightBlack": "#473f37",
+  "brightRed": "#ae1111",
+  "brightGreen": "#33612d",
+  "brightYellow": "#804913",
+  "brightBlue": "#225d75",
+  "brightPurple": "#7222d2",
+  "brightCyan": "#345e52",
+  "brightWhite": "#43430e"
+}

--- a/extras/windows-terminal/themes/light/5/oasis_twilight_light_5.json
+++ b/extras/windows-terminal/themes/light/5/oasis_twilight_light_5.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Twilight Light 5",
+  "background": "#dbc8ec",
+  "foreground": "#181811",
+  "cursorColor": "#953519",
+  "selectionBackground": "#bd9bdc",
+  "black": "#323232",
+  "red": "#940e0e",
+  "green": "#2e512b",
+  "yellow": "#4f4a1a",
+  "blue": "#104a83",
+  "purple": "#621db1",
+  "cyan": "#2d4f45",
+  "white": "#343418",
+  "brightBlack": "#38312b",
+  "brightRed": "#940e0e",
+  "brightGreen": "#2b5126",
+  "brightYellow": "#6c3e10",
+  "brightBlue": "#1c4e63",
+  "brightPurple": "#611db2",
+  "brightCyan": "#2c5045",
+  "brightWhite": "#34340b"
+}


### PR DESCRIPTION
Closes #26.

## What this adds

Two new extras, so the Windows ecosystem gets the same first-class theme support the repo already provides for Kitty, Ghostty, Alacritty and friends.

**`extras/windows-terminal/`** — generates one Windows Terminal color scheme JSON object per variant (96 files: 16 themes x 1 dark + 5 light intensities), plus a README covering how to paste a scheme into the `"schemes"` array in `settings.json` and reference it as `colorScheme`.

**`extras/psreadline/`** — generates one PowerShell script per variant that calls `Set-PSReadLineOption -Colors` with 24-bit truecolor ANSI escapes, plus a README covering copying it and dot-sourcing it from `$PROFILE`.

Both generators follow the existing extras conventions: standalone Lua run from the repo root, iteration via `Utils.for_each_palette_variant`, paths via `Utils.build_variant_path`, and the `Success: N` / `Errors: N` summary that `extras/run_all_generators.lua` parses. Discovery is automatic, so no orchestrator changes were needed. Generated output is committed, matching every other extra. The root README extras table gained a row for each.

## Decisions worth knowing about

**Hand-rolled JSON instead of `ColorUtils.encode_json`.** That helper sorts keys alphabetically. Windows Terminal schemes are much easier to read in canonical order (`name`, `background`, `foreground`, `cursorColor`, `selectionBackground`, then the 16 ANSI slots), so the JSON is emitted by hand, the same way `extras/json-theme` and `extras/nless` already do it.

**Windows Terminal calls the magenta slots `purple` / `brightPurple`.** The palette's `magenta` / `bright_magenta` are mapped onto those key names. This is Windows Terminal's actual schema, not a typo.

**Truecolor escapes rather than PowerShell's 16 logical color names.** The requester's own hand-made config used logical names (`Command = 'Yellow'`) because he switches light/dark automatically and wanted one config to serve both. Because we generate a separate file per theme variant, we can instead map tokens directly onto the exact Oasis syntax palette, which is meaningfully more faithful than approximating through the console's 16 slots. Anyone who wants the auto-switching behavior can still keep their logical-name config; this gives everyone else the real colors.

**`$esc = [char]0x1B` instead of the `` `e `` escape.** The `` `e `` form is PowerShell 6+ only. Defining `$esc` and interpolating it works on Windows PowerShell 5.1 as well as 7+, which matters because PSReadLine ships with both.

**`palette.ui.visual.fg` is not usable.** It resolves to the literal string `"none"` — the Neovim highlight sentinel meaning "inherit" — in all 96 variants of every theme, and feeding it to `ColorUtils.hex_to_rgb` crashes. No existing generator reads that field (they all use `.bg` only). The two PSReadLine tokens needing a selection foreground (`Selection`, `ListPredictionSelected`) use `palette.fg.core` instead, which is the closest faithful translation of "inherit the normal foreground". Flagging it in case that sentinel is itself considered a palette bug worth fixing separately.

**`NEWS.md` deliberately untouched**, matching the precedent set by `fd1ede7a` (the nless generator), which added a whole new extra without a NEWS entry.

## Independent review

Codex reviewed the diff independently (`codex exec --sandbox read-only`), with the generators, the generated output, the two new READMEs, and the root README table all in scope. It found one issue, which was fixed:

- **Generated `.ps1` headers used the wrong comment marker.** They emitted `# name:` / `# author:`, while existing extras emit `## name:` / `## author:` (see `extras/alacritty/themes/dark/oasis_mirage_dark.toml`). Fixed and all 96 files regenerated. Nothing was rejected — this was a fair call.

Codex explicitly verified and passed: all 96 Windows Terminal JSON files parse; the key names match Microsoft's documented color-scheme schema including `purple`/`brightPurple`; every PSReadLine `-Colors` key used is a real documented key with none conspicuously missing; the `$esc` interpolation approach is valid PowerShell; both Lua scripts pass `luac -p`; and no generated file contains a missing or nil value.

I found two more issues in my own pass, both also fixed:

- The header path line inside each generated `.ps1` printed `extras/psreadline/oasis_<name>.ps1` rather than the real path `extras/psreadline/themes/dark/oasis_<name>.ps1`. There is mixed precedent here (alacritty prints the true path, kitty prints a truncated one); I followed alacritty, since a header pointing at a nonexistent path is simply wrong.
- Both generators used a `-- stylua: on` terminator, which is not a real stylua directive — it is a typo copied from `extras/nless/generate_nless.lua`. Both now use the paired `-- stylua: ignore start` / `-- stylua: ignore end` form that `lua/oasis/palette.lua` uses. I left the pre-existing typo in nless alone as out of scope.

## Please double-check

- **The PSReadLine token mapping is a judgment call and would benefit from your eye**, which is exactly what the requester asked for in the issue. Current mapping: `Command` -> `syntax.func`, `Keyword` -> `syntax.statement`, `Variable` -> `syntax.builtin_var`, `Member` -> `syntax.identifier`, `Number` -> `syntax.constant`, `String` -> `syntax.string`, `Type` -> `syntax.type`, `Operator` -> `syntax.operator`, `Parameter` -> `syntax.parameter`, `Emphasis` -> `theme.accent`, `Error` -> `ui.diag.error.fg`, and the three prediction tokens -> `fg.dim`. These are my reading of the intent, not anything the palette declares.
- **Nothing here has been run on Windows.** The JSON was validated as JSON and the color-scheme schema was checked against Microsoft's docs, and the PowerShell was checked for valid syntax and valid `-Colors` key names, but no scheme has been loaded in a real Windows Terminal and no `.ps1` has been dot-sourced in a real PowerShell session. It would be worth having the issue reporter try one before this ships, since he has the environment.
- **Two pre-existing repo conditions surfaced while working and were left untouched**, but you may want to know: `stylua .` across the whole repo reformats 96 already-committed `extras/lua-theme/themes/**/*.lua` files plus `extras/vscode/generate_vscode.lua` and `lua/oasis/lib/override_palette.lua` (they are not currently stylua-clean); and `extras/foot/generate_foot.lua` and `extras/vimium-c/generate_vimiumc.lua` fail to parse under stylua's default Lua syntax mode. Only the two new generator files were style-checked here, precisely to avoid dragging those unrelated changes in.
- **`extras/run_all_generators.lua` labels the new extras `Windows-terminal` and `Psreadline`** in its summary output, because it derives the label from the directory name. That matches how `gemini-cli` and `dark-reader` already print, so I left the orchestrator alone rather than adding a display-name mechanism.

## Note on repo conventions

This repository has no `AGENTS.md`, so conventions here were inferred from the existing generators, `.stylua.toml`, and the shape of the nless commit (`fd1ede7a`) as the precedent for adding a new extra. If any of the above diverges from what you actually want, that is the likely reason.
