### PR TITLE
Add Windows Terminal and PSReadLine extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,38 +149,40 @@ To use the extras, refer to their respective documentation.
 
 <!-- extras:start -->
 
-| Tool        | Extra                                                  |
-| ----------- | ------------------------------------------------------ |
-| Alacritty   | [extras/alacritty](extras/alacritty)                   |
-| Bat         | [extras/bat](extras/bat)                               |
-| Btop        | [extras/btop](extras/btop)                             |
-| Dark Reader | [extras/dark-reader](/extras/dark-reader)              |
-| Firefox     | [extras/firefox](extras/firefox)                       |
-| Foot        | [extras/foot](extras/foot)                             |
-| FZF         | [extras/fzf](extras/fzf)                               |
-| Gemini CLI  | [extras/gemini-cli](extras/gemini-cli)                 |
-| Ghostty     | [extras/ghostty](extras/ghostty)                       |
-| iTerm       | [extras/iterm](extras/iterm)                           |
-| JSON-theme  | [extras/json-theme](/extras/json-theme)                |
-| Kitty       | [extras/kitty](extras/kitty)                           |
-| Konsole     | [extras/konsole](extras/konsole)                       |
-| LazyGit     | [extras/lazygit](extras/lazygit)                       |
-| Lua-theme   | [extras/lua-theme](/extras/lua-theme)                  |
-| Nless       | [extras/nless](/extras/nless)                          |
-| Qutebrowser | [extras/qutebrowser](extras/qutebrowser)               |
-| Slack       | [extras/slack](extras/slack)                           |
-| Starship    | [extras/starship](extras/starship)                     |
-| Termux      | [extras/termux](extras/termux)                         |
-| Thunderbird | [extras/thunderbird](extras/thunderbird)               |
-| Tridactyl   | [extras/tridactyl](extras/tridactyl)                   |
-| TMUX        | [tmux-oasis](https://github.com/uhs-robert/tmux-oasis) |
-| Vimium      | [extras/vimium](extras/vimium)                         |
-| Vimium C    | [extras/vimium-c](extras/vimium-c)                     |
-| VS Code     | [extras/vscode](extras/vscode)                         |
-| Warp        | [extras/warp](extras/warp)                             |
-| WezTerm     | [extras/wezterm](extras/wezterm)                       |
-| Yazi        | [extras/yazi](extras/yazi)                             |
-| Zed         | [extras/zed](extras/zed)                               |
+| Tool             | Extra                                                  |
+| ---------------- | ------------------------------------------------------ |
+| Alacritty        | [extras/alacritty](extras/alacritty)                   |
+| Bat              | [extras/bat](extras/bat)                               |
+| Btop             | [extras/btop](extras/btop)                             |
+| Dark Reader      | [extras/dark-reader](/extras/dark-reader)              |
+| Firefox          | [extras/firefox](extras/firefox)                       |
+| Foot             | [extras/foot](extras/foot)                             |
+| FZF              | [extras/fzf](extras/fzf)                               |
+| Gemini CLI       | [extras/gemini-cli](extras/gemini-cli)                 |
+| Ghostty          | [extras/ghostty](extras/ghostty)                       |
+| iTerm            | [extras/iterm](extras/iterm)                           |
+| JSON-theme       | [extras/json-theme](/extras/json-theme)                |
+| Kitty            | [extras/kitty](extras/kitty)                           |
+| Konsole          | [extras/konsole](extras/konsole)                       |
+| LazyGit          | [extras/lazygit](extras/lazygit)                       |
+| Lua-theme        | [extras/lua-theme](/extras/lua-theme)                  |
+| Nless            | [extras/nless](/extras/nless)                          |
+| PSReadLine       | [extras/psreadline](extras/psreadline)                 |
+| Qutebrowser      | [extras/qutebrowser](extras/qutebrowser)               |
+| Slack            | [extras/slack](extras/slack)                           |
+| Starship         | [extras/starship](extras/starship)                     |
+| Termux           | [extras/termux](extras/termux)                         |
+| Thunderbird      | [extras/thunderbird](extras/thunderbird)               |
+| Tridactyl        | [extras/tridactyl](extras/tridactyl)                   |
+| TMUX             | [tmux-oasis](https://github.com/uhs-robert/tmux-oasis) |
+| Vimium           | [extras/vimium](extras/vimium)                         |
+| Vimium C         | [extras/vimium-c](extras/vimium-c)                     |
+| VS Code          | [extras/vscode](extras/vscode)                         |
+| Warp             | [extras/warp](extras/warp)                             |
+| WezTerm          | [extras/wezterm](extras/wezterm)                       |
+| Windows Terminal | [extras/windows-terminal](extras/windows-terminal)     |
+| Yazi             | [extras/yazi](extras/yazi)                             |
+| Zed              | [extras/zed](extras/zed)                               |
 
 If you'd like an extra config added, raise a feature request and I'll put it together.
 

--- a/extras/psreadline/README.md
+++ b/extras/psreadline/README.md
@@ -1,0 +1,19 @@
+# PSReadLine Setup
+
+[PSReadLine](https://github.com/PowerShell/PSReadLine) provides syntax highlighting and prediction for PowerShell's command line.
+
+> [!NOTE]
+> These scripts use the `` `e `` escape character, which requires PowerShell 6+ (`pwsh`, including PowerShell 7). Windows PowerShell 5.1's parser does not support `` `e `` — on 5.1 replace it with `$([char]27)` in the script before sourcing it, or install PowerShell 7.
+
+1. Pick the `dark` folder, or the `light/<1-5>` folder matching the intensity you use elsewhere (e.g. your Windows Terminal scheme), and copy the `.ps1` file you want.
+2. Dot-source it from your `$PROFILE`:
+
+```powershell
+. path\to\oasis_lagoon_dark.ps1
+```
+
+3. Or run it once in your current session to try it out:
+
+```powershell
+& path\to\oasis_lagoon_dark.ps1
+```

--- a/extras/psreadline/generate_psreadline.lua
+++ b/extras/psreadline/generate_psreadline.lua
@@ -1,0 +1,96 @@
+#!/usr/bin/env lua
+-- extras/psreadline/generate_psreadline.lua
+-- Generates PSReadLine color config scripts from Oasis color palettes
+
+-- Load shared utilities
+package.path = package.path .. ";./lua/?.lua;./lua/?/init.lua"
+local Utils = require("oasis.utils")
+local File = require("oasis.lib.file")
+local ColorUtils = require("oasis.tools.color_utils")
+
+local function ansi(hex)
+  local rgb = ColorUtils.hex_to_rgb(hex):gsub(",", ";")
+  return "`e[38;2;" .. rgb .. "m"
+end
+
+-- PSReadLine's own defaults render Comment/InlinePrediction in italic
+local function ansi_italic(hex)
+  local rgb = ColorUtils.hex_to_rgb(hex):gsub(",", ";")
+  return "`e[3;38;2;" .. rgb .. "m"
+end
+
+local REVERSE_VIDEO = "`e[7m"
+
+local function generate_psreadline_theme(name, palette)
+  local display_name = Utils.format_display_name(name)
+
+  -- stylua: ignore
+  local fields = {
+    { "Command",                  ansi(palette.syntax.statement) },
+    { "Comment",                  ansi_italic(palette.syntax.comment) },
+    { "ContinuationPrompt",       ansi(palette.fg.muted) },
+    { "Default",                  ansi(palette.fg.core) },
+    { "Emphasis",                 ansi(palette.theme.accent) },
+    { "Error",                    ansi(palette.ui.diag.error.fg) },
+    { "InlinePrediction",         ansi_italic(palette.fg.dim) },
+    { "Keyword",                  ansi(palette.syntax.conditional) },
+    { "ListPrediction",           ansi(palette.theme.secondary) },
+    { "ListPredictionSelected",   REVERSE_VIDEO },
+    { "ListPredictionTooltip",    ansi(palette.fg.muted) },
+    { "Member",                   ansi(palette.syntax.func) },
+    { "Number",                   ansi(palette.syntax.constant) },
+    { "Operator",                 ansi(palette.syntax.operator) },
+    { "Parameter",                ansi(palette.syntax.parameter) },
+    { "Selection",                REVERSE_VIDEO },
+    { "String",                   ansi(palette.syntax.string) },
+    { "Type",                     ansi(palette.syntax.type) },
+    { "Variable",                 ansi(palette.syntax.identifier) },
+  }
+  -- stylua: on
+
+  local lines = {
+    "# extras/psreadline/themes/.../oasis_" .. name .. ".ps1",
+    "# name: " .. display_name,
+    "# author: uhs-robert",
+    "",
+    "Set-PSReadLineOption -Colors @{",
+  }
+
+  for _, field in ipairs(fields) do
+    lines[#lines + 1] = string.format('    %s = "%s"', field[1], field[2])
+  end
+
+  lines[#lines + 1] = "}"
+
+  return table.concat(lines, "\n")
+end
+
+local function main()
+  print("\n=== Oasis PSReadLine Theme Generator ===\n")
+
+  local palette_names = Utils.get_palette_names()
+
+  if #palette_names == 0 then
+    print("Error: No palette files found in lua/oasis/color_palettes/")
+    return
+  end
+
+  print(string.format("Found %d palette(s)\n", #palette_names))
+
+  local success_count, error_count = Utils.for_each_palette_variant(function(name, palette, mode, intensity)
+    -- Build output path using shared utility
+    local output_path, variant_name = Utils.build_variant_path("extras/psreadline", "ps1", name, mode, intensity)
+
+    -- Generate and write theme
+    local theme = generate_psreadline_theme(variant_name, palette)
+    File.write(output_path, theme)
+    print(string.format("✓ Generated: %s", output_path))
+  end)
+
+  print(string.format("\n=== Summary ==="))
+  print(string.format("Success: %d", success_count))
+  print(string.format("Errors: %d\n", error_count))
+end
+
+-- Run the generator
+main()

--- a/extras/psreadline/themes/dark/oasis_abyss_dark.ps1
+++ b/extras/psreadline/themes/dark/oasis_abyss_dark.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_abyss_dark.ps1
+# name: Oasis Abyss Dark
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;216;207;127m"
+    Comment = "`e[3;38;2;122;118;98m"
+    ContinuationPrompt = "`e[38;2;96;92;77m"
+    Default = "`e[38;2;245;245;220m"
+    Emphasis = "`e[38;2;127;207;120m"
+    Error = "`e[38;2;255;160;160m"
+    InlinePrediction = "`e[3;38;2;123;120;109m"
+    Keyword = "`e[38;2;189;183;107m"
+    ListPrediction = "`e[38;2;255;121;121m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;96;92;77m"
+    Member = "`e[38;2;233;192;165m"
+    Number = "`e[38;2;255;150;51m"
+    Operator = "`e[38;2;205;198;115m"
+    Parameter = "`e[38;2;127;207;120m"
+    Selection = "`e[7m"
+    String = "`e[38;2;255;160;160m"
+    Type = "`e[38;2;124;205;181m"
+    Variable = "`e[38;2;135;206;235m"
+}

--- a/extras/psreadline/themes/dark/oasis_cactus_dark.ps1
+++ b/extras/psreadline/themes/dark/oasis_cactus_dark.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_cactus_dark.ps1
+# name: Oasis Cactus Dark
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;174;214;176m"
+    Comment = "`e[3;38;2;105;149;109m"
+    ContinuationPrompt = "`e[38;2;91;115;96m"
+    Default = "`e[38;2;245;245;220m"
+    Emphasis = "`e[38;2;255;160;160m"
+    Error = "`e[38;2;255;160;160m"
+    InlinePrediction = "`e[3;38;2;116;132;119m"
+    Keyword = "`e[38;2;147;199;149m"
+    ListPrediction = "`e[38;2;210;173;255m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;91;115;96m"
+    Member = "`e[38;2;233;192;165m"
+    Number = "`e[38;2;255;163;77m"
+    Operator = "`e[38;2;167;211;169m"
+    Parameter = "`e[38;2;255;208;92m"
+    Selection = "`e[7m"
+    String = "`e[38;2;255;160;160m"
+    Type = "`e[38;2;124;205;181m"
+    Variable = "`e[38;2;135;206;235m"
+}

--- a/extras/psreadline/themes/dark/oasis_canyon_dark.ps1
+++ b/extras/psreadline/themes/dark/oasis_canyon_dark.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_canyon_dark.ps1
+# name: Oasis Canyon Dark
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;249;175;150m"
+    Comment = "`e[3;38;2;182;126;97m"
+    ContinuationPrompt = "`e[38;2;154;101;73m"
+    Default = "`e[38;2;245;245;220m"
+    Emphasis = "`e[38;2;255;144;144m"
+    Error = "`e[38;2;255;160;160m"
+    InlinePrediction = "`e[3;38;2;137;124;117m"
+    Keyword = "`e[38;2;226;142;111m"
+    ListPrediction = "`e[38;2;148;208;254m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;154;101;73m"
+    Member = "`e[38;2;240;230;140m"
+    Number = "`e[38;2;255;163;77m"
+    Operator = "`e[38;2;249;175;150m"
+    Parameter = "`e[38;2;127;207;120m"
+    Selection = "`e[7m"
+    String = "`e[38;2;255;160;160m"
+    Type = "`e[38;2;124;205;181m"
+    Variable = "`e[38;2;135;206;235m"
+}

--- a/extras/psreadline/themes/dark/oasis_desert_dark.ps1
+++ b/extras/psreadline/themes/dark/oasis_desert_dark.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_desert_dark.ps1
+# name: Oasis Desert Dark
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;240;230;140m"
+    Comment = "`e[3;38;2;148;143;122m"
+    ContinuationPrompt = "`e[38;2;119;114;95m"
+    Default = "`e[38;2;245;245;220m"
+    Emphasis = "`e[38;2;127;207;120m"
+    Error = "`e[38;2;255;160;160m"
+    InlinePrediction = "`e[3;38;2;135;132;120m"
+    Keyword = "`e[38;2;189;183;107m"
+    ListPrediction = "`e[38;2;255;121;121m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;119;114;95m"
+    Member = "`e[38;2;233;192;165m"
+    Number = "`e[38;2;255;163;77m"
+    Operator = "`e[38;2;216;207;127m"
+    Parameter = "`e[38;2;127;207;120m"
+    Selection = "`e[7m"
+    String = "`e[38;2;255;160;160m"
+    Type = "`e[38;2;124;205;181m"
+    Variable = "`e[38;2;135;206;235m"
+}

--- a/extras/psreadline/themes/dark/oasis_dune_dark.ps1
+++ b/extras/psreadline/themes/dark/oasis_dune_dark.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_dune_dark.ps1
+# name: Oasis Dune Dark
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;240;230;140m"
+    Comment = "`e[3;38;2;159;139;121m"
+    ContinuationPrompt = "`e[38;2;130;109;90m"
+    Default = "`e[38;2;245;245;220m"
+    Emphasis = "`e[38;2;105;195;170m"
+    Error = "`e[38;2;255;160;160m"
+    InlinePrediction = "`e[3;38;2;142;131;122m"
+    Keyword = "`e[38;2;189;183;107m"
+    ListPrediction = "`e[38;2;216;154;114m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;130;109;90m"
+    Member = "`e[38;2;233;192;165m"
+    Number = "`e[38;2;255;163;77m"
+    Operator = "`e[38;2;216;207;127m"
+    Parameter = "`e[38;2;127;207;120m"
+    Selection = "`e[7m"
+    String = "`e[38;2;255;160;160m"
+    Type = "`e[38;2;124;205;181m"
+    Variable = "`e[38;2;135;206;235m"
+}

--- a/extras/psreadline/themes/dark/oasis_lagoon_dark.ps1
+++ b/extras/psreadline/themes/dark/oasis_lagoon_dark.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_lagoon_dark.ps1
+# name: Oasis Lagoon Dark
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;113;184;255m"
+    Comment = "`e[3;38;2;77;136;167m"
+    ContinuationPrompt = "`e[38;2;59;106;135m"
+    Default = "`e[38;2;245;245;220m"
+    Emphasis = "`e[38;2;255;160;160m"
+    Error = "`e[38;2;255;160;160m"
+    InlinePrediction = "`e[3;38;2;114;127;134m"
+    Keyword = "`e[38;2;58;172;253m"
+    ListPrediction = "`e[38;2;248;180;113m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;59;106;135m"
+    Member = "`e[38;2;233;192;165m"
+    Number = "`e[38;2;255;163;77m"
+    Operator = "`e[38;2;129;192;255m"
+    Parameter = "`e[38;2;127;207;120m"
+    Selection = "`e[7m"
+    String = "`e[38;2;255;160;160m"
+    Type = "`e[38;2;243;234;159m"
+    Variable = "`e[38;2;165;220;241m"
+}

--- a/extras/psreadline/themes/dark/oasis_luna_dark.ps1
+++ b/extras/psreadline/themes/dark/oasis_luna_dark.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_luna_dark.ps1
+# name: Oasis Luna Dark
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;216;207;127m"
+    Comment = "`e[3;38;2;162;154;201m"
+    ContinuationPrompt = "`e[38;2;138;130;179m"
+    Default = "`e[38;2;245;245;220m"
+    Emphasis = "`e[38;2;109;206;235m"
+    Error = "`e[38;2;255;160;160m"
+    InlinePrediction = "`e[3;38;2;124;120;140m"
+    Keyword = "`e[38;2;189;183;107m"
+    ListPrediction = "`e[38;2;151;151;233m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;138;130;179m"
+    Member = "`e[38;2;233;192;165m"
+    Number = "`e[38;2;255;150;51m"
+    Operator = "`e[38;2;205;198;115m"
+    Parameter = "`e[38;2;127;207;120m"
+    Selection = "`e[7m"
+    String = "`e[38;2;255;160;160m"
+    Type = "`e[38;2;124;205;181m"
+    Variable = "`e[38;2;135;206;235m"
+}

--- a/extras/psreadline/themes/dark/oasis_midnight_dark.ps1
+++ b/extras/psreadline/themes/dark/oasis_midnight_dark.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_midnight_dark.ps1
+# name: Oasis Midnight Dark
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;216;207;127m"
+    Comment = "`e[3;38;2;105;128;157m"
+    ContinuationPrompt = "`e[38;2;78;101;120m"
+    Default = "`e[38;2;245;245;220m"
+    Emphasis = "`e[38;2;127;207;120m"
+    Error = "`e[38;2;255;160;160m"
+    InlinePrediction = "`e[3;38;2;111;122;131m"
+    Keyword = "`e[38;2;189;183;107m"
+    ListPrediction = "`e[38;2;255;121;121m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;78;101;120m"
+    Member = "`e[38;2;233;192;165m"
+    Number = "`e[38;2;255;163;77m"
+    Operator = "`e[38;2;205;198;115m"
+    Parameter = "`e[38;2;127;207;120m"
+    Selection = "`e[7m"
+    String = "`e[38;2;255;160;160m"
+    Type = "`e[38;2;124;205;181m"
+    Variable = "`e[38;2;135;206;235m"
+}

--- a/extras/psreadline/themes/dark/oasis_mirage_dark.ps1
+++ b/extras/psreadline/themes/dark/oasis_mirage_dark.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_mirage_dark.ps1
+# name: Oasis Mirage Dark
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;138;211;190m"
+    Comment = "`e[3;38;2;67;151;137m"
+    ContinuationPrompt = "`e[38;2;88;114;112m"
+    Default = "`e[38;2;245;245;220m"
+    Emphasis = "`e[38;2;210;173;255m"
+    Error = "`e[38;2;255;160;160m"
+    InlinePrediction = "`e[3;38;2;115;130;129m"
+    Keyword = "`e[38;2;85;182;157m"
+    ListPrediction = "`e[38;2;248;180;113m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;88;114;112m"
+    Member = "`e[38;2;233;192;165m"
+    Number = "`e[38;2;255;163;77m"
+    Operator = "`e[38;2;124;205;181m"
+    Parameter = "`e[38;2;127;207;120m"
+    Selection = "`e[7m"
+    String = "`e[38;2;255;160;160m"
+    Type = "`e[38;2;243;234;159m"
+    Variable = "`e[38;2;135;206;235m"
+}

--- a/extras/psreadline/themes/dark/oasis_moonlight_dark.ps1
+++ b/extras/psreadline/themes/dark/oasis_moonlight_dark.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_moonlight_dark.ps1
+# name: Oasis Moonlight Dark
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;216;207;127m"
+    Comment = "`e[3;38;2;105;128;157m"
+    ContinuationPrompt = "`e[38;2;78;101;120m"
+    Default = "`e[38;2;245;245;220m"
+    Emphasis = "`e[38;2;255;160;160m"
+    Error = "`e[38;2;255;160;160m"
+    InlinePrediction = "`e[3;38;2;113;122;132m"
+    Keyword = "`e[38;2;189;183;107m"
+    ListPrediction = "`e[38;2;240;230;140m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;78;101;120m"
+    Member = "`e[38;2;233;192;165m"
+    Number = "`e[38;2;255;150;51m"
+    Operator = "`e[38;2;205;198;115m"
+    Parameter = "`e[38;2;127;207;120m"
+    Selection = "`e[7m"
+    String = "`e[38;2;255;160;160m"
+    Type = "`e[38;2;124;205;181m"
+    Variable = "`e[38;2;135;206;235m"
+}

--- a/extras/psreadline/themes/dark/oasis_night_dark.ps1
+++ b/extras/psreadline/themes/dark/oasis_night_dark.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_night_dark.ps1
+# name: Oasis Night Dark
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;216;207;127m"
+    Comment = "`e[3;38;2;112;140;168m"
+    ContinuationPrompt = "`e[38;2;83;107;131m"
+    Default = "`e[38;2;245;245;220m"
+    Emphasis = "`e[38;2;255;160;160m"
+    Error = "`e[38;2;255;160;160m"
+    InlinePrediction = "`e[3;38;2;114;123;133m"
+    Keyword = "`e[38;2;189;183;107m"
+    ListPrediction = "`e[38;2;240;230;140m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;83;107;131m"
+    Member = "`e[38;2;233;192;165m"
+    Number = "`e[38;2;255;150;51m"
+    Operator = "`e[38;2;205;198;115m"
+    Parameter = "`e[38;2;127;207;120m"
+    Selection = "`e[7m"
+    String = "`e[38;2;255;160;160m"
+    Type = "`e[38;2;124;205;181m"
+    Variable = "`e[38;2;135;206;235m"
+}

--- a/extras/psreadline/themes/dark/oasis_rose_dark.ps1
+++ b/extras/psreadline/themes/dark/oasis_rose_dark.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_rose_dark.ps1
+# name: Oasis Rose Dark
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;236;181;203m"
+    Comment = "`e[3;38;2;168;122;145m"
+    ContinuationPrompt = "`e[38;2;129;97;117m"
+    Default = "`e[38;2;245;245;220m"
+    Emphasis = "`e[38;2;124;205;181m"
+    Error = "`e[38;2;255;160;160m"
+    InlinePrediction = "`e[3;38;2;140;125;134m"
+    Keyword = "`e[38;2;223;147;177m"
+    ListPrediction = "`e[38;2;147;199;149m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;129;97;117m"
+    Member = "`e[38;2;233;192;165m"
+    Number = "`e[38;2;255;150;51m"
+    Operator = "`e[38;2;223;147;177m"
+    Parameter = "`e[38;2;127;207;120m"
+    Selection = "`e[7m"
+    String = "`e[38;2;255;160;160m"
+    Type = "`e[38;2;124;205;181m"
+    Variable = "`e[38;2;135;206;235m"
+}

--- a/extras/psreadline/themes/dark/oasis_scorpion_dark.ps1
+++ b/extras/psreadline/themes/dark/oasis_scorpion_dark.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_scorpion_dark.ps1
+# name: Oasis Scorpion Dark
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;216;207;127m"
+    Comment = "`e[3;38;2;176;138;128m"
+    ContinuationPrompt = "`e[38;2;154;111;102m"
+    Default = "`e[38;2;245;245;220m"
+    Emphasis = "`e[38;2;216;207;127m"
+    Error = "`e[38;2;255;160;160m"
+    InlinePrediction = "`e[3;38;2;131;117;112m"
+    Keyword = "`e[38;2;189;183;107m"
+    ListPrediction = "`e[38;2;247;153;125m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;154;111;102m"
+    Member = "`e[38;2;233;192;165m"
+    Number = "`e[38;2;255;163;77m"
+    Operator = "`e[38;2;205;198;115m"
+    Parameter = "`e[38;2;127;207;120m"
+    Selection = "`e[7m"
+    String = "`e[38;2;255;160;160m"
+    Type = "`e[38;2;124;205;181m"
+    Variable = "`e[38;2;135;206;235m"
+}

--- a/extras/psreadline/themes/dark/oasis_sol_dark.ps1
+++ b/extras/psreadline/themes/dark/oasis_sol_dark.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_sol_dark.ps1
+# name: Oasis Sol Dark
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;243;148;147m"
+    Comment = "`e[3;38;2;162;125;120m"
+    ContinuationPrompt = "`e[38;2;131;97;91m"
+    Default = "`e[38;2;245;245;220m"
+    Emphasis = "`e[38;2;127;207;120m"
+    Error = "`e[38;2;255;160;160m"
+    InlinePrediction = "`e[3;38;2;126;126;126m"
+    Keyword = "`e[38;2;255;128;128m"
+    ListPrediction = "`e[38;2;248;180;113m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;131;97;91m"
+    Member = "`e[38;2;233;192;165m"
+    Number = "`e[38;2;255;150;51m"
+    Operator = "`e[38;2;245;139;139m"
+    Parameter = "`e[38;2;127;207;120m"
+    Selection = "`e[7m"
+    String = "`e[38;2;216;207;127m"
+    Type = "`e[38;2;124;205;181m"
+    Variable = "`e[38;2;135;206;235m"
+}

--- a/extras/psreadline/themes/dark/oasis_starlight_dark.ps1
+++ b/extras/psreadline/themes/dark/oasis_starlight_dark.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_starlight_dark.ps1
+# name: Oasis Starlight Dark
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;216;207;127m"
+    Comment = "`e[3;38;2;94;124;154m"
+    ContinuationPrompt = "`e[38;2;79;91;107m"
+    Default = "`e[38;2;245;245;220m"
+    Emphasis = "`e[38;2;255;160;160m"
+    Error = "`e[38;2;255;160;160m"
+    InlinePrediction = "`e[3;38;2;110;125;129m"
+    Keyword = "`e[38;2;199;179;94m"
+    ListPrediction = "`e[38;2;240;230;140m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;79;91;107m"
+    Member = "`e[38;2;233;192;165m"
+    Number = "`e[38;2;255;150;51m"
+    Operator = "`e[38;2;205;198;115m"
+    Parameter = "`e[38;2;127;207;120m"
+    Selection = "`e[7m"
+    String = "`e[38;2;255;144;144m"
+    Type = "`e[38;2;124;205;181m"
+    Variable = "`e[38;2;135;206;235m"
+}

--- a/extras/psreadline/themes/dark/oasis_twilight_dark.ps1
+++ b/extras/psreadline/themes/dark/oasis_twilight_dark.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_twilight_dark.ps1
+# name: Oasis Twilight Dark
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;249;175;150m"
+    Comment = "`e[3;38;2;139;128;170m"
+    ContinuationPrompt = "`e[38;2;113;96;154m"
+    Default = "`e[38;2;245;245;220m"
+    Emphasis = "`e[38;2;240;230;140m"
+    Error = "`e[38;2;255;160;160m"
+    InlinePrediction = "`e[3;38;2;127;122;141m"
+    Keyword = "`e[38;2;226;142;111m"
+    ListPrediction = "`e[38;2;210;173;255m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;113;96;154m"
+    Member = "`e[38;2;240;230;140m"
+    Number = "`e[38;2;255;163;77m"
+    Operator = "`e[38;2;249;175;150m"
+    Parameter = "`e[38;2;127;207;120m"
+    Selection = "`e[7m"
+    String = "`e[38;2;255;160;160m"
+    Type = "`e[38;2;124;205;181m"
+    Variable = "`e[38;2;146;211;237m"
+}

--- a/extras/psreadline/themes/light/1/oasis_abyss_light_1.ps1
+++ b/extras/psreadline/themes/light/1/oasis_abyss_light_1.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_abyss_light_1.ps1
+# name: Oasis Abyss Light 1
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;110;100;44m"
+    Comment = "`e[3;38;2;107;104;93m"
+    ContinuationPrompt = "`e[38;2;106;104;95m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;56;128;50m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;134;133;127m"
+    Keyword = "`e[38;2;94;88;50m"
+    ListPrediction = "`e[38;2;135;6;6m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;106;104;95m"
+    Member = "`e[38;2;104;67;45m"
+    Number = "`e[38;2;155;80;17m"
+    Operator = "`e[38;2;94;89;42m"
+    Parameter = "`e[38;2;54;104;50m"
+    Selection = "`e[7m"
+    String = "`e[38;2;152;17;22m"
+    Type = "`e[38;2;51;103;88m"
+    Variable = "`e[38;2;38;100;125m"
+}

--- a/extras/psreadline/themes/light/1/oasis_cactus_light_1.ps1
+++ b/extras/psreadline/themes/light/1/oasis_cactus_light_1.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_cactus_light_1.ps1
+# name: Oasis Cactus Light 1
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;70;121;73m"
+    Comment = "`e[3;38;2;96;120;99m"
+    ContinuationPrompt = "`e[38;2;105;117;107m"
+    Default = "`e[38;2;28;28;19m"
+    Emphasis = "`e[38;2;171;7;7m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;138;145;140m"
+    Keyword = "`e[38;2;63;107;66m"
+    ListPrediction = "`e[38;2;64;6;135m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;105;117;107m"
+    Member = "`e[38;2;117;75;50m"
+    Number = "`e[38;2;170;87;19m"
+    Operator = "`e[38;2;62;107;64m"
+    Parameter = "`e[38;2;133;96;19m"
+    Selection = "`e[7m"
+    String = "`e[38;2;170;19;24m"
+    Type = "`e[38;2;56;113;96m"
+    Variable = "`e[38;2;42;110;137m"
+}

--- a/extras/psreadline/themes/light/1/oasis_canyon_light_1.ps1
+++ b/extras/psreadline/themes/light/1/oasis_canyon_light_1.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_canyon_light_1.ps1
+# name: Oasis Canyon Light 1
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;174;61;29m"
+    Comment = "`e[3;38;2;130;96;80m"
+    ContinuationPrompt = "`e[38;2;120;99;89m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;171;7;7m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;136;131;127m"
+    Keyword = "`e[38;2;139;65;42m"
+    ListPrediction = "`e[38;2;7;78;133m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;120;99;89m"
+    Member = "`e[38;2;82;75;28m"
+    Number = "`e[38;2;154;79;17m"
+    Operator = "`e[38;2;153;54;26m"
+    Parameter = "`e[38;2;53;104;50m"
+    Selection = "`e[7m"
+    String = "`e[38;2;151;16;22m"
+    Type = "`e[38;2;50;102;87m"
+    Variable = "`e[38;2;38;99;124m"
+}

--- a/extras/psreadline/themes/light/1/oasis_desert_light_1.ps1
+++ b/extras/psreadline/themes/light/1/oasis_desert_light_1.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_desert_light_1.ps1
+# name: Oasis Desert Light 1
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;122;109;28m"
+    Comment = "`e[3;38;2;116;113;101m"
+    ContinuationPrompt = "`e[38;2;115;113;103m"
+    Default = "`e[38;2;27;27;19m"
+    Emphasis = "`e[38;2;56;128;50m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;144;143;137m"
+    Keyword = "`e[38;2;103;97;54m"
+    ListPrediction = "`e[38;2;135;6;6m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;115;113;103m"
+    Member = "`e[38;2;116;74;50m"
+    Number = "`e[38;2;169;87;18m"
+    Operator = "`e[38;2;106;97;42m"
+    Parameter = "`e[38;2;59;114;55m"
+    Selection = "`e[7m"
+    String = "`e[38;2;168;18;24m"
+    Type = "`e[38;2;55;112;96m"
+    Variable = "`e[38;2;41;109;136m"
+}

--- a/extras/psreadline/themes/light/1/oasis_dune_light_1.ps1
+++ b/extras/psreadline/themes/light/1/oasis_dune_light_1.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_dune_light_1.ps1
+# name: Oasis Dune Light 1
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;122;110;29m"
+    Comment = "`e[3;38;2;125;111;102m"
+    ContinuationPrompt = "`e[38;2;122;112;102m"
+    Default = "`e[38;2;28;28;19m"
+    Emphasis = "`e[38;2;54;124;105m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;148;143;139m"
+    Keyword = "`e[38;2;104;98;55m"
+    ListPrediction = "`e[38;2;107;62;34m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;122;112;102m"
+    Member = "`e[38;2;116;75;50m"
+    Number = "`e[38;2;170;87;19m"
+    Operator = "`e[38;2;106;97;42m"
+    Parameter = "`e[38;2;59;115;55m"
+    Selection = "`e[7m"
+    String = "`e[38;2;169;18;24m"
+    Type = "`e[38;2;56;113;96m"
+    Variable = "`e[38;2;42;110;137m"
+}

--- a/extras/psreadline/themes/light/1/oasis_lagoon_light_1.ps1
+++ b/extras/psreadline/themes/light/1/oasis_lagoon_light_1.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_lagoon_light_1.ps1
+# name: Oasis Lagoon Light 1
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;23;107;209m"
+    Comment = "`e[3;38;2;85;117;139m"
+    ContinuationPrompt = "`e[38;2;96;117;129m"
+    Default = "`e[38;2;27;27;19m"
+    Emphasis = "`e[38;2;171;7;7m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;139;144;147m"
+    Keyword = "`e[38;2;20;99;167m"
+    ListPrediction = "`e[38;2;129;70;12m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;96;117;129m"
+    Member = "`e[38;2;116;74;50m"
+    Number = "`e[38;2;170;87;19m"
+    Operator = "`e[38;2;20;95;185m"
+    Parameter = "`e[38;2;59;115;55m"
+    Selection = "`e[7m"
+    String = "`e[38;2;169;18;24m"
+    Type = "`e[38;2;114;103;30m"
+    Variable = "`e[38;2;40;110;136m"
+}

--- a/extras/psreadline/themes/light/1/oasis_luna_light_1.ps1
+++ b/extras/psreadline/themes/light/1/oasis_luna_light_1.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_luna_light_1.ps1
+# name: Oasis Luna Light 1
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;118;108;47m"
+    Comment = "`e[3;38;2;117;105;154m"
+    ContinuationPrompt = "`e[38;2;113;109;129m"
+    Default = "`e[38;2;25;25;17m"
+    Emphasis = "`e[38;2;27;123;152m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;141;140;149m"
+    Keyword = "`e[38;2;102;96;54m"
+    ListPrediction = "`e[38;2;28;28;112m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;113;109;129m"
+    Member = "`e[38;2;114;73;49m"
+    Number = "`e[38;2;167;85;18m"
+    Operator = "`e[38;2;102;96;46m"
+    Parameter = "`e[38;2;58;113;54m"
+    Selection = "`e[7m"
+    String = "`e[38;2;166;18;24m"
+    Type = "`e[38;2;55;111;95m"
+    Variable = "`e[38;2;41;108;135m"
+}

--- a/extras/psreadline/themes/light/1/oasis_midnight_light_1.ps1
+++ b/extras/psreadline/themes/light/1/oasis_midnight_light_1.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_midnight_light_1.ps1
+# name: Oasis Midnight Light 1
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;115;105;46m"
+    Comment = "`e[3;38;2;98;110;129m"
+    ContinuationPrompt = "`e[38;2;100;110;119m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;56;128;50m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;133;139;143m"
+    Keyword = "`e[38;2;99;93;52m"
+    ListPrediction = "`e[38;2;135;6;6m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;100;110;119m"
+    Member = "`e[38;2;110;71;47m"
+    Number = "`e[38;2;162;83;18m"
+    Operator = "`e[38;2;99;93;45m"
+    Parameter = "`e[38;2;56;110;52m"
+    Selection = "`e[7m"
+    String = "`e[38;2;160;18;23m"
+    Type = "`e[38;2;53;108;92m"
+    Variable = "`e[38;2;40;105;131m"
+}

--- a/extras/psreadline/themes/light/1/oasis_mirage_light_1.ps1
+++ b/extras/psreadline/themes/light/1/oasis_mirage_light_1.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_mirage_light_1.ps1
+# name: Oasis Mirage Light 1
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;56;121;104m"
+    Comment = "`e[3;38;2;75;123;115m"
+    ContinuationPrompt = "`e[38;2;103;117;116m"
+    Default = "`e[38;2;28;28;20m"
+    Emphasis = "`e[38;2;81;7;171m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;139;145;145m"
+    Keyword = "`e[38;2;55;106;94m"
+    ListPrediction = "`e[38;2;129;70;12m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;103;117;116m"
+    Member = "`e[38;2;117;75;50m"
+    Number = "`e[38;2;170;87;19m"
+    Operator = "`e[38;2;51;107;90m"
+    Parameter = "`e[38;2;59;115;55m"
+    Selection = "`e[7m"
+    String = "`e[38;2;170;19;24m"
+    Type = "`e[38;2;115;104;30m"
+    Variable = "`e[38;2;42;111;138m"
+}

--- a/extras/psreadline/themes/light/1/oasis_moonlight_light_1.ps1
+++ b/extras/psreadline/themes/light/1/oasis_moonlight_light_1.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_moonlight_light_1.ps1
+# name: Oasis Moonlight Light 1
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;117;107;47m"
+    Comment = "`e[3;38;2;100;111;131m"
+    ContinuationPrompt = "`e[38;2;102;112;120m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;171;7;7m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;136;140;145m"
+    Keyword = "`e[38;2;100;95;53m"
+    ListPrediction = "`e[38;2;120;110;20m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;102;112;120m"
+    Member = "`e[38;2;113;72;49m"
+    Number = "`e[38;2;165;85;18m"
+    Operator = "`e[38;2;101;95;45m"
+    Parameter = "`e[38;2;57;112;53m"
+    Selection = "`e[7m"
+    String = "`e[38;2;164;18;23m"
+    Type = "`e[38;2;54;110;94m"
+    Variable = "`e[38;2;41;107;133m"
+}

--- a/extras/psreadline/themes/light/1/oasis_night_light_1.ps1
+++ b/extras/psreadline/themes/light/1/oasis_night_light_1.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_night_light_1.ps1
+# name: Oasis Night Light 1
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;119;109;47m"
+    Comment = "`e[3;38;2;98;114;135m"
+    ContinuationPrompt = "`e[38;2;104;114;123m"
+    Default = "`e[38;2;26;26;18m"
+    Emphasis = "`e[38;2;171;7;7m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;138;143;147m"
+    Keyword = "`e[38;2;102;96;54m"
+    ListPrediction = "`e[38;2;120;110;20m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;104;114;123m"
+    Member = "`e[38;2;115;74;49m"
+    Number = "`e[38;2;168;86;18m"
+    Operator = "`e[38;2;102;97;46m"
+    Parameter = "`e[38;2;58;114;54m"
+    Selection = "`e[7m"
+    String = "`e[38;2;167;18;24m"
+    Type = "`e[38;2;55;111;95m"
+    Variable = "`e[38;2;41;109;136m"
+}

--- a/extras/psreadline/themes/light/1/oasis_rose_light_1.ps1
+++ b/extras/psreadline/themes/light/1/oasis_rose_light_1.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_rose_light_1.ps1
+# name: Oasis Rose Light 1
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;179;64;110m"
+    Comment = "`e[3;38;2;133;102;116m"
+    ContinuationPrompt = "`e[38;2;122;106;116m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;53;126;104m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;144;138;142m"
+    Keyword = "`e[38;2;153;61;97m"
+    ListPrediction = "`e[38;2;50;91;51m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;122;106;116m"
+    Member = "`e[38;2;112;72;48m"
+    Number = "`e[38;2;164;84;18m"
+    Operator = "`e[38;2;153;61;97m"
+    Parameter = "`e[38;2;57;111;53m"
+    Selection = "`e[7m"
+    String = "`e[38;2;163;18;23m"
+    Type = "`e[38;2;54;109;93m"
+    Variable = "`e[38;2;40;107;133m"
+}

--- a/extras/psreadline/themes/light/1/oasis_scorpion_light_1.ps1
+++ b/extras/psreadline/themes/light/1/oasis_scorpion_light_1.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_scorpion_light_1.ps1
+# name: Oasis Scorpion Light 1
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;111;101;44m"
+    Comment = "`e[3;38;2;126;98;94m"
+    ContinuationPrompt = "`e[38;2;117;102;99m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;133;124;45m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;139;132;130m"
+    Keyword = "`e[38;2;95;89;50m"
+    ListPrediction = "`e[38;2;127;39;13m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;117;102;99m"
+    Member = "`e[38;2;105;67;45m"
+    Number = "`e[38;2;156;80;17m"
+    Operator = "`e[38;2;95;89;43m"
+    Parameter = "`e[38;2;54;105;50m"
+    Selection = "`e[7m"
+    String = "`e[38;2;153;17;22m"
+    Type = "`e[38;2;51;103;88m"
+    Variable = "`e[38;2;38;101;126m"
+}

--- a/extras/psreadline/themes/light/1/oasis_sol_light_1.ps1
+++ b/extras/psreadline/themes/light/1/oasis_sol_light_1.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_sol_light_1.ps1
+# name: Oasis Sol Light 1
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;185;41;44m"
+    Comment = "`e[3;38;2;120;96;94m"
+    ContinuationPrompt = "`e[38;2;115;98;95m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;56;128;50m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;130;130;130m"
+    Keyword = "`e[38;2;170;19;24m"
+    ListPrediction = "`e[38;2;129;70;12m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;115;98;95m"
+    Member = "`e[38;2;101;65;44m"
+    Number = "`e[38;2;151;78;17m"
+    Operator = "`e[38;2;164;33;37m"
+    Parameter = "`e[38;2;52;102;49m"
+    Selection = "`e[7m"
+    String = "`e[38;2;80;74;32m"
+    Type = "`e[38;2;50;100;85m"
+    Variable = "`e[38;2;37;98;122m"
+}

--- a/extras/psreadline/themes/light/1/oasis_starlight_light_1.ps1
+++ b/extras/psreadline/themes/light/1/oasis_starlight_light_1.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_starlight_light_1.ps1
+# name: Oasis Starlight Light 1
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;121;111;49m"
+    Comment = "`e[3;38;2;100;117;138m"
+    ContinuationPrompt = "`e[38;2;108;116;126m"
+    Default = "`e[38;2;30;30;20m"
+    Emphasis = "`e[38;2;171;7;7m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;140;146;148m"
+    Keyword = "`e[38;2;112;97;50m"
+    ListPrediction = "`e[38;2;120;110;20m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;108;116;126m"
+    Member = "`e[38;2;118;76;51m"
+    Number = "`e[38;2;172;88;19m"
+    Operator = "`e[38;2;105;99;47m"
+    Parameter = "`e[38;2;60;116;56m"
+    Selection = "`e[7m"
+    String = "`e[38;2;172;19;25m"
+    Type = "`e[38;2;56;114;97m"
+    Variable = "`e[38;2;42;111;139m"
+}

--- a/extras/psreadline/themes/light/1/oasis_twilight_light_1.ps1
+++ b/extras/psreadline/themes/light/1/oasis_twilight_light_1.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_twilight_light_1.ps1
+# name: Oasis Twilight Light 1
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;190;67;32m"
+    Comment = "`e[3;38;2;118;108;141m"
+    ContinuationPrompt = "`e[38;2;116;110;130m"
+    Default = "`e[38;2;27;27;19m"
+    Emphasis = "`e[38;2;152;140;26m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;143;141;149m"
+    Keyword = "`e[38;2;153;72;47m"
+    ListPrediction = "`e[38;2;64;6;135m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;116;110;130m"
+    Member = "`e[38;2;92;84;31m"
+    Number = "`e[38;2;168;86;18m"
+    Operator = "`e[38;2;169;59;28m"
+    Parameter = "`e[38;2;59;114;54m"
+    Selection = "`e[7m"
+    String = "`e[38;2;168;18;24m"
+    Type = "`e[38;2;55;112;96m"
+    Variable = "`e[38;2;41;109;136m"
+}

--- a/extras/psreadline/themes/light/2/oasis_abyss_light_2.ps1
+++ b/extras/psreadline/themes/light/2/oasis_abyss_light_2.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_abyss_light_2.ps1
+# name: Oasis Abyss Light 2
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;105;96;42m"
+    Comment = "`e[3;38;2;103;100;90m"
+    ContinuationPrompt = "`e[38;2;102;100;92m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;53;122;47m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;130;128;122m"
+    Keyword = "`e[38;2;89;84;47m"
+    ListPrediction = "`e[38;2;126;4;4m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;102;100;92m"
+    Member = "`e[38;2;98;63;43m"
+    Number = "`e[38;2;149;76;16m"
+    Operator = "`e[38;2;90;84;41m"
+    Parameter = "`e[38;2;52;100;47m"
+    Selection = "`e[7m"
+    String = "`e[38;2;144;16;21m"
+    Type = "`e[38;2;49;98;84m"
+    Variable = "`e[38;2;37;96;119m"
+}

--- a/extras/psreadline/themes/light/2/oasis_cactus_light_2.ps1
+++ b/extras/psreadline/themes/light/2/oasis_cactus_light_2.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_cactus_light_2.ps1
+# name: Oasis Cactus Light 2
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;68;116;71m"
+    Comment = "`e[3;38;2;92;116;94m"
+    ContinuationPrompt = "`e[38;2;100;113;103m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;163;5;5m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;134;141;135m"
+    Keyword = "`e[38;2;61;103;63m"
+    ListPrediction = "`e[38;2;59;4;126m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;100;113;103m"
+    Member = "`e[38;2;112;72;49m"
+    Number = "`e[38;2;164;84;18m"
+    Operator = "`e[38;2;59;103;61m"
+    Parameter = "`e[38;2;128;93;18m"
+    Selection = "`e[7m"
+    String = "`e[38;2;163;18;24m"
+    Type = "`e[38;2;54;109;93m"
+    Variable = "`e[38;2;41;106;132m"
+}

--- a/extras/psreadline/themes/light/2/oasis_canyon_light_2.ps1
+++ b/extras/psreadline/themes/light/2/oasis_canyon_light_2.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_canyon_light_2.ps1
+# name: Oasis Canyon Light 2
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;167;59;29m"
+    Comment = "`e[3;38;2;125;91;76m"
+    ContinuationPrompt = "`e[38;2;114;95;85m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;163;5;5m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;133;126;122m"
+    Keyword = "`e[38;2;132;62;41m"
+    ListPrediction = "`e[38;2;5;73;125m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;114;95;85m"
+    Member = "`e[38;2;78;71;26m"
+    Number = "`e[38;2;148;75;16m"
+    Operator = "`e[38;2;146;51;25m"
+    Parameter = "`e[38;2;51;99;47m"
+    Selection = "`e[7m"
+    String = "`e[38;2;143;16;21m"
+    Type = "`e[38;2;49;97;83m"
+    Variable = "`e[38;2;36;95;118m"
+}

--- a/extras/psreadline/themes/light/2/oasis_desert_light_2.ps1
+++ b/extras/psreadline/themes/light/2/oasis_desert_light_2.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_desert_light_2.ps1
+# name: Oasis Desert Light 2
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;119;107;29m"
+    Comment = "`e[3;38;2;114;111;99m"
+    ContinuationPrompt = "`e[38;2;113;111;102m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;53;122;47m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;141;140;133m"
+    Keyword = "`e[38;2;100;95;52m"
+    ListPrediction = "`e[38;2;126;4;4m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;113;111;102m"
+    Member = "`e[38;2;112;72;49m"
+    Number = "`e[38;2;165;84;18m"
+    Operator = "`e[38;2;103;94;41m"
+    Parameter = "`e[38;2;58;111;53m"
+    Selection = "`e[7m"
+    String = "`e[38;2;163;18;24m"
+    Type = "`e[38;2;55;109;93m"
+    Variable = "`e[38;2;41;107;133m"
+}

--- a/extras/psreadline/themes/light/2/oasis_dune_light_2.ps1
+++ b/extras/psreadline/themes/light/2/oasis_dune_light_2.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_dune_light_2.ps1
+# name: Oasis Dune Light 2
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;118;106;29m"
+    Comment = "`e[3;38;2;121;108;98m"
+    ContinuationPrompt = "`e[38;2;119;108;99m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;50;118;99m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;144;139;134m"
+    Keyword = "`e[38;2;99;94;52m"
+    ListPrediction = "`e[38;2;100;58;30m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;119;108;99m"
+    Member = "`e[38;2;112;72;49m"
+    Number = "`e[38;2;165;84;18m"
+    Operator = "`e[38;2;102;94;41m"
+    Parameter = "`e[38;2;58;111;52m"
+    Selection = "`e[7m"
+    String = "`e[38;2;163;18;24m"
+    Type = "`e[38;2;55;109;93m"
+    Variable = "`e[38;2;41;106;132m"
+}

--- a/extras/psreadline/themes/light/2/oasis_lagoon_light_2.ps1
+++ b/extras/psreadline/themes/light/2/oasis_lagoon_light_2.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_lagoon_light_2.ps1
+# name: Oasis Lagoon Light 2
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;22;104;204m"
+    Comment = "`e[3;38;2;82;114;134m"
+    ContinuationPrompt = "`e[38;2;92;113;126m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;163;5;5m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;134;140;144m"
+    Keyword = "`e[38;2;19;96;161m"
+    ListPrediction = "`e[38;2;120;65;10m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;92;113;126m"
+    Member = "`e[38;2;112;72;49m"
+    Number = "`e[38;2;165;84;18m"
+    Operator = "`e[38;2;20;92;180m"
+    Parameter = "`e[38;2;58;111;52m"
+    Selection = "`e[7m"
+    String = "`e[38;2;163;18;24m"
+    Type = "`e[38;2;111;100;29m"
+    Variable = "`e[38;2;39;106;132m"
+}

--- a/extras/psreadline/themes/light/2/oasis_luna_light_2.ps1
+++ b/extras/psreadline/themes/light/2/oasis_luna_light_2.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_luna_light_2.ps1
+# name: Oasis Luna Light 2
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;114;105;46m"
+    Comment = "`e[3;38;2;113;101;151m"
+    ContinuationPrompt = "`e[38;2;109;106;127m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;24;117;144m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;138;136;145m"
+    Keyword = "`e[38;2;97;93;51m"
+    ListPrediction = "`e[38;2;25;25;105m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;109;106;127m"
+    Member = "`e[38;2;109;70;48m"
+    Number = "`e[38;2;162;82;18m"
+    Operator = "`e[38;2;98;93;45m"
+    Parameter = "`e[38;2;56;109;51m"
+    Selection = "`e[7m"
+    String = "`e[38;2;159;17;23m"
+    Type = "`e[38;2;53;107;91m"
+    Variable = "`e[38;2;40;104;130m"
+}

--- a/extras/psreadline/themes/light/2/oasis_midnight_light_2.ps1
+++ b/extras/psreadline/themes/light/2/oasis_midnight_light_2.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_midnight_light_2.ps1
+# name: Oasis Midnight Light 2
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;109;100;44m"
+    Comment = "`e[3;38;2;93;104;122m"
+    ContinuationPrompt = "`e[38;2;96;105;112m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;53;122;47m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;127;133;137m"
+    Keyword = "`e[38;2;93;88;49m"
+    ListPrediction = "`e[38;2;126;4;4m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;96;105;112m"
+    Member = "`e[38;2;103;66;45m"
+    Number = "`e[38;2;155;79;17m"
+    Operator = "`e[38;2;94;88;42m"
+    Parameter = "`e[38;2;54;104;49m"
+    Selection = "`e[7m"
+    String = "`e[38;2;151;16;22m"
+    Type = "`e[38;2;51;102;87m"
+    Variable = "`e[38;2;38;99;124m"
+}

--- a/extras/psreadline/themes/light/2/oasis_mirage_light_2.ps1
+++ b/extras/psreadline/themes/light/2/oasis_mirage_light_2.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_mirage_light_2.ps1
+# name: Oasis Mirage Light 2
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;55;117;100m"
+    Comment = "`e[3;38;2;72;120;111m"
+    ContinuationPrompt = "`e[38;2;100;114;113m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;76;5;163m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;134;142;142m"
+    Keyword = "`e[38;2;53;103;90m"
+    ListPrediction = "`e[38;2;120;65;10m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;100;114;113m"
+    Member = "`e[38;2;113;72;49m"
+    Number = "`e[38;2;166;84;18m"
+    Operator = "`e[38;2;49;103;87m"
+    Parameter = "`e[38;2;58;112;53m"
+    Selection = "`e[7m"
+    String = "`e[38;2;164;18;24m"
+    Type = "`e[38;2;111;100;29m"
+    Variable = "`e[38;2;41;107;133m"
+}

--- a/extras/psreadline/themes/light/2/oasis_moonlight_light_2.ps1
+++ b/extras/psreadline/themes/light/2/oasis_moonlight_light_2.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_moonlight_light_2.ps1
+# name: Oasis Moonlight Light 2
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;112;103;45m"
+    Comment = "`e[3;38;2;96;107;126m"
+    ContinuationPrompt = "`e[38;2;99;108;116m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;163;5;5m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;132;136;141m"
+    Keyword = "`e[38;2;96;91;50m"
+    ListPrediction = "`e[38;2;112;103;18m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;99;108;116m"
+    Member = "`e[38;2;107;69;47m"
+    Number = "`e[38;2;159;81;17m"
+    Operator = "`e[38;2;97;91;44m"
+    Parameter = "`e[38;2;56;107;51m"
+    Selection = "`e[7m"
+    String = "`e[38;2;157;17;23m"
+    Type = "`e[38;2;53;105;90m"
+    Variable = "`e[38;2;39;103;128m"
+}

--- a/extras/psreadline/themes/light/2/oasis_night_light_2.ps1
+++ b/extras/psreadline/themes/light/2/oasis_night_light_2.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_night_light_2.ps1
+# name: Oasis Night Light 2
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;113;103;45m"
+    Comment = "`e[3;38;2;93;108;128m"
+    ContinuationPrompt = "`e[38;2;98;109;118m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;163;5;5m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;132;136;142m"
+    Keyword = "`e[38;2;96;91;51m"
+    ListPrediction = "`e[38;2;112;103;18m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;98;109;118m"
+    Member = "`e[38;2;108;69;47m"
+    Number = "`e[38;2;160;81;17m"
+    Operator = "`e[38;2;97;91;44m"
+    Parameter = "`e[38;2;56;108;51m"
+    Selection = "`e[7m"
+    String = "`e[38;2;157;17;23m"
+    Type = "`e[38;2;53;106;90m"
+    Variable = "`e[38;2;40;103;128m"
+}

--- a/extras/psreadline/themes/light/2/oasis_rose_light_2.ps1
+++ b/extras/psreadline/themes/light/2/oasis_rose_light_2.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_rose_light_2.ps1
+# name: Oasis Rose Light 2
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;170;60;104m"
+    Comment = "`e[3;38;2;126;96;111m"
+    ContinuationPrompt = "`e[38;2;116;100;109m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;49;120;99m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;139;131;135m"
+    Keyword = "`e[38;2;144;57;92m"
+    ListPrediction = "`e[38;2;46;84;47m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;116;100;109m"
+    Member = "`e[38;2;104;67;45m"
+    Number = "`e[38;2;156;79;17m"
+    Operator = "`e[38;2;144;57;92m"
+    Parameter = "`e[38;2;54;105;49m"
+    Selection = "`e[7m"
+    String = "`e[38;2;153;17;22m"
+    Type = "`e[38;2;51;103;88m"
+    Variable = "`e[38;2;38;100;125m"
+}

--- a/extras/psreadline/themes/light/2/oasis_scorpion_light_2.ps1
+++ b/extras/psreadline/themes/light/2/oasis_scorpion_light_2.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_scorpion_light_2.ps1
+# name: Oasis Scorpion Light 2
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;104;96;42m"
+    Comment = "`e[3;38;2;118;93;87m"
+    ContinuationPrompt = "`e[38;2;110;96;93m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;126;118;42m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;133;126;122m"
+    Keyword = "`e[38;2;88;84;46m"
+    ListPrediction = "`e[38;2;119;36;11m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;110;96;93m"
+    Member = "`e[38;2;97;63;42m"
+    Number = "`e[38;2;148;75;16m"
+    Operator = "`e[38;2;89;84;40m"
+    Parameter = "`e[38;2;52;99;47m"
+    Selection = "`e[7m"
+    String = "`e[38;2;143;16;21m"
+    Type = "`e[38;2;49;97;83m"
+    Variable = "`e[38;2;36;95;118m"
+}

--- a/extras/psreadline/themes/light/2/oasis_sol_light_2.ps1
+++ b/extras/psreadline/themes/light/2/oasis_sol_light_2.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_sol_light_2.ps1
+# name: Oasis Sol Light 2
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;174;38;42m"
+    Comment = "`e[3;38;2;112;91;88m"
+    ContinuationPrompt = "`e[38;2;107;92;90m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;53;122;47m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;123;123;123m"
+    Keyword = "`e[38;2;159;17;23m"
+    ListPrediction = "`e[38;2;120;65;10m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;107;92;90m"
+    Member = "`e[38;2;93;60;40m"
+    Number = "`e[38;2;143;73;16m"
+    Operator = "`e[38;2;154;30;35m"
+    Parameter = "`e[38;2;50;95;45m"
+    Selection = "`e[7m"
+    String = "`e[38;2;74;68;30m"
+    Type = "`e[38;2;47;94;80m"
+    Variable = "`e[38;2;35;91;114m"
+}

--- a/extras/psreadline/themes/light/2/oasis_starlight_light_2.ps1
+++ b/extras/psreadline/themes/light/2/oasis_starlight_light_2.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_starlight_light_2.ps1
+# name: Oasis Starlight Light 2
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;121;111;49m"
+    Comment = "`e[3;38;2;100;116;137m"
+    ContinuationPrompt = "`e[38;2;108;115;126m"
+    Default = "`e[38;2;29;29;20m"
+    Emphasis = "`e[38;2;163;5;5m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;138;146;148m"
+    Keyword = "`e[38;2;111;97;50m"
+    ListPrediction = "`e[38;2;112;103;18m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;108;115;126m"
+    Member = "`e[38;2;118;75;51m"
+    Number = "`e[38;2;172;87;19m"
+    Operator = "`e[38;2;105;99;47m"
+    Parameter = "`e[38;2;60;116;55m"
+    Selection = "`e[7m"
+    String = "`e[38;2;171;19;25m"
+    Type = "`e[38;2;57;114;97m"
+    Variable = "`e[38;2;42;111;138m"
+}

--- a/extras/psreadline/themes/light/2/oasis_twilight_light_2.ps1
+++ b/extras/psreadline/themes/light/2/oasis_twilight_light_2.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_twilight_light_2.ps1
+# name: Oasis Twilight Light 2
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;181;64;31m"
+    Comment = "`e[3;38;2;112;103;133m"
+    ContinuationPrompt = "`e[38;2;110;105;123m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;145;133;23m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;138;135;144m"
+    Keyword = "`e[38;2;145;68;45m"
+    ListPrediction = "`e[38;2;59;4;126m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;110;105;123m"
+    Member = "`e[38;2;86;79;29m"
+    Number = "`e[38;2;161;82;18m"
+    Operator = "`e[38;2;160;56;27m"
+    Parameter = "`e[38;2;56;108;51m"
+    Selection = "`e[7m"
+    String = "`e[38;2;158;17;23m"
+    Type = "`e[38;2;53;106;90m"
+    Variable = "`e[38;2;39;104;130m"
+}

--- a/extras/psreadline/themes/light/3/oasis_abyss_light_3.ps1
+++ b/extras/psreadline/themes/light/3/oasis_abyss_light_3.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_abyss_light_3.ps1
+# name: Oasis Abyss Light 3
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;99;92;40m"
+    Comment = "`e[3;38;2;98;95;84m"
+    ContinuationPrompt = "`e[38;2;97;95;87m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;49;115;43m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;124;122;116m"
+    Keyword = "`e[38;2;83;79;44m"
+    ListPrediction = "`e[38;2;117;2;2m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;97;95;87m"
+    Member = "`e[38;2;91;59;40m"
+    Number = "`e[38;2;141;72;15m"
+    Operator = "`e[38;2;84;79;38m"
+    Parameter = "`e[38;2;49;94;45m"
+    Selection = "`e[7m"
+    String = "`e[38;2;135;15;19m"
+    Type = "`e[38;2;46;93;79m"
+    Variable = "`e[38;2;34;90;114m"
+}

--- a/extras/psreadline/themes/light/3/oasis_cactus_light_3.ps1
+++ b/extras/psreadline/themes/light/3/oasis_cactus_light_3.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_cactus_light_3.ps1
+# name: Oasis Cactus Light 3
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;65;113;68m"
+    Comment = "`e[3;38;2;89;112;92m"
+    ContinuationPrompt = "`e[38;2;97;109;100m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;155;3;3m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;129;137;130m"
+    Keyword = "`e[38;2;59;98;60m"
+    ListPrediction = "`e[38;2;54;2;117m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;97;109;100m"
+    Member = "`e[38;2;106;69;46m"
+    Number = "`e[38;2;158;81;17m"
+    Operator = "`e[38;2;57;99;60m"
+    Parameter = "`e[38;2;124;89;18m"
+    Selection = "`e[7m"
+    String = "`e[38;2;156;17;22m"
+    Type = "`e[38;2;52;105;89m"
+    Variable = "`e[38;2;39;102;129m"
+}

--- a/extras/psreadline/themes/light/3/oasis_canyon_light_3.ps1
+++ b/extras/psreadline/themes/light/3/oasis_canyon_light_3.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_canyon_light_3.ps1
+# name: Oasis Canyon Light 3
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;159;56;26m"
+    Comment = "`e[3;38;2;119;88;74m"
+    ContinuationPrompt = "`e[38;2;109;91;82m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;155;3;3m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;128;121;117m"
+    Keyword = "`e[38;2;126;59;38m"
+    ListPrediction = "`e[38;2;3;67;116m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;109;91;82m"
+    Member = "`e[38;2;73;67;25m"
+    Number = "`e[38;2;140;72;15m"
+    Operator = "`e[38;2;138;49;23m"
+    Parameter = "`e[38;2;48;94;45m"
+    Selection = "`e[7m"
+    String = "`e[38;2;134;15;19m"
+    Type = "`e[38;2;46;92;79m"
+    Variable = "`e[38;2;34;90;114m"
+}

--- a/extras/psreadline/themes/light/3/oasis_desert_light_3.ps1
+++ b/extras/psreadline/themes/light/3/oasis_desert_light_3.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_desert_light_3.ps1
+# name: Oasis Desert Light 3
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;116;103;28m"
+    Comment = "`e[3;38;2;111;107;96m"
+    ContinuationPrompt = "`e[38;2;110;107;98m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;49;115;43m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;138;136;130m"
+    Keyword = "`e[38;2;96;92;51m"
+    ListPrediction = "`e[38;2;117;2;2m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;110;107;98m"
+    Member = "`e[38;2;108;70;47m"
+    Number = "`e[38;2;160;82;17m"
+    Operator = "`e[38;2;99;92;40m"
+    Parameter = "`e[38;2;56;108;51m"
+    Selection = "`e[7m"
+    String = "`e[38;2;158;17;22m"
+    Type = "`e[38;2;53;106;91m"
+    Variable = "`e[38;2;39;103;131m"
+}

--- a/extras/psreadline/themes/light/3/oasis_dune_light_3.ps1
+++ b/extras/psreadline/themes/light/3/oasis_dune_light_3.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_dune_light_3.ps1
+# name: Oasis Dune Light 3
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;115;102;28m"
+    Comment = "`e[3;38;2;118;104;95m"
+    ContinuationPrompt = "`e[38;2;114;105;96m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;47;112;94m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;140;134;130m"
+    Keyword = "`e[38;2;95;91;51m"
+    ListPrediction = "`e[38;2;93;53;27m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;114;105;96m"
+    Member = "`e[38;2;107;69;46m"
+    Number = "`e[38;2;158;81;17m"
+    Operator = "`e[38;2;98;90;39m"
+    Parameter = "`e[38;2;55;107;51m"
+    Selection = "`e[7m"
+    String = "`e[38;2;156;17;22m"
+    Type = "`e[38;2;52;105;90m"
+    Variable = "`e[38;2;39;102;129m"
+}

--- a/extras/psreadline/themes/light/3/oasis_lagoon_light_3.ps1
+++ b/extras/psreadline/themes/light/3/oasis_lagoon_light_3.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_lagoon_light_3.ps1
+# name: Oasis Lagoon Light 3
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;21;99;193m"
+    Comment = "`e[3;38;2;80;109;129m"
+    ContinuationPrompt = "`e[38;2;88;108;120m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;155;3;3m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;128;135;138m"
+    Keyword = "`e[38;2;18;90;153m"
+    ListPrediction = "`e[38;2;112;60;8m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;88;108;120m"
+    Member = "`e[38;2;105;68;46m"
+    Number = "`e[38;2;156;80;17m"
+    Operator = "`e[38;2;18;87;169m"
+    Parameter = "`e[38;2;54;106;50m"
+    Selection = "`e[7m"
+    String = "`e[38;2;154;17;21m"
+    Type = "`e[38;2;106;94;28m"
+    Variable = "`e[38;2;36;101;126m"
+}

--- a/extras/psreadline/themes/light/3/oasis_luna_light_3.ps1
+++ b/extras/psreadline/themes/light/3/oasis_luna_light_3.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_luna_light_3.ps1
+# name: Oasis Luna Light 3
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;106;98;42m"
+    Comment = "`e[3;38;2;105;95;141m"
+    ContinuationPrompt = "`e[38;2;102;99;118m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;21;110;137m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;130;128;138m"
+    Keyword = "`e[38;2;89;86;48m"
+    ListPrediction = "`e[38;2;22;22;97m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;102;99;118m"
+    Member = "`e[38;2;100;65;43m"
+    Number = "`e[38;2;150;77;16m"
+    Operator = "`e[38;2;91;86;41m"
+    Parameter = "`e[38;2;52;101;48m"
+    Selection = "`e[7m"
+    String = "`e[38;2;147;16;20m"
+    Type = "`e[38;2;49;99;85m"
+    Variable = "`e[38;2;37;97;122m"
+}

--- a/extras/psreadline/themes/light/3/oasis_midnight_light_3.ps1
+++ b/extras/psreadline/themes/light/3/oasis_midnight_light_3.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_midnight_light_3.ps1
+# name: Oasis Midnight Light 3
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;103;95;41m"
+    Comment = "`e[3;38;2;89;99;117m"
+    ContinuationPrompt = "`e[38;2;90;100;107m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;49;115;43m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;121;127;132m"
+    Keyword = "`e[38;2;87;83;46m"
+    ListPrediction = "`e[38;2;117;2;2m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;90;100;107m"
+    Member = "`e[38;2;96;62;42m"
+    Number = "`e[38;2;146;75;16m"
+    Operator = "`e[38;2;88;83;40m"
+    Parameter = "`e[38;2;51;98;47m"
+    Selection = "`e[7m"
+    String = "`e[38;2;142;15;20m"
+    Type = "`e[38;2;48;96;82m"
+    Variable = "`e[38;2;36;94;119m"
+}

--- a/extras/psreadline/themes/light/3/oasis_mirage_light_3.ps1
+++ b/extras/psreadline/themes/light/3/oasis_mirage_light_3.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_mirage_light_3.ps1
+# name: Oasis Mirage Light 3
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;54;114;97m"
+    Comment = "`e[3;38;2;69;116;107m"
+    ContinuationPrompt = "`e[38;2;96;110;109m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;72;3;155m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;130;138;137m"
+    Keyword = "`e[38;2;51;99;87m"
+    ListPrediction = "`e[38;2;112;60;8m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;96;110;109m"
+    Member = "`e[38;2;108;70;47m"
+    Number = "`e[38;2;160;82;17m"
+    Operator = "`e[38;2;47;100;84m"
+    Parameter = "`e[38;2;56;108;51m"
+    Selection = "`e[7m"
+    String = "`e[38;2;158;17;22m"
+    Type = "`e[38;2;108;97;29m"
+    Variable = "`e[38;2;39;103;131m"
+}

--- a/extras/psreadline/themes/light/3/oasis_moonlight_light_3.ps1
+++ b/extras/psreadline/themes/light/3/oasis_moonlight_light_3.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_moonlight_light_3.ps1
+# name: Oasis Moonlight Light 3
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;107;99;43m"
+    Comment = "`e[3;38;2;93;103;122m"
+    ContinuationPrompt = "`e[38;2;94;104;112m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;155;3;3m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;127;132;137m"
+    Keyword = "`e[38;2;91;87;49m"
+    ListPrediction = "`e[38;2;104;95;16m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;94;104;112m"
+    Member = "`e[38;2;102;66;44m"
+    Number = "`e[38;2;153;79;17m"
+    Operator = "`e[38;2;92;87;42m"
+    Parameter = "`e[38;2;53;103;49m"
+    Selection = "`e[7m"
+    String = "`e[38;2;149;16;21m"
+    Type = "`e[38;2;50;101;86m"
+    Variable = "`e[38;2;37;98;124m"
+}

--- a/extras/psreadline/themes/light/3/oasis_night_light_3.ps1
+++ b/extras/psreadline/themes/light/3/oasis_night_light_3.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_night_light_3.ps1
+# name: Oasis Night Light 3
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;104;96;42m"
+    Comment = "`e[3;38;2;87;101;119m"
+    ContinuationPrompt = "`e[38;2;92;101;110m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;155;3;3m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;124;129;134m"
+    Keyword = "`e[38;2;88;84;47m"
+    ListPrediction = "`e[38;2;104;95;16m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;92;101;110m"
+    Member = "`e[38;2;98;63;43m"
+    Number = "`e[38;2;148;76;16m"
+    Operator = "`e[38;2;89;85;41m"
+    Parameter = "`e[38;2;52;100;47m"
+    Selection = "`e[7m"
+    String = "`e[38;2;144;16;20m"
+    Type = "`e[38;2;48;98;84m"
+    Variable = "`e[38;2;36;95;121m"
+}

--- a/extras/psreadline/themes/light/3/oasis_rose_light_3.ps1
+++ b/extras/psreadline/themes/light/3/oasis_rose_light_3.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_rose_light_3.ps1
+# name: Oasis Rose Light 3
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;159;58;98m"
+    Comment = "`e[3;38;2;119;90;104m"
+    ContinuationPrompt = "`e[38;2;108;95;103m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;45;113;93m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;132;124;129m"
+    Keyword = "`e[38;2;135;54;86m"
+    ListPrediction = "`e[38;2;42;78;43m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;108;95;103m"
+    Member = "`e[38;2;96;62;42m"
+    Number = "`e[38;2;146;75;16m"
+    Operator = "`e[38;2;135;54;86m"
+    Parameter = "`e[38;2;51;98;47m"
+    Selection = "`e[7m"
+    String = "`e[38;2;142;15;20m"
+    Type = "`e[38;2;48;96;82m"
+    Variable = "`e[38;2;36;94;119m"
+}

--- a/extras/psreadline/themes/light/3/oasis_scorpion_light_3.ps1
+++ b/extras/psreadline/themes/light/3/oasis_scorpion_light_3.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_scorpion_light_3.ps1
+# name: Oasis Scorpion Light 3
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;98;91;39m"
+    Comment = "`e[3;38;2;113;89;84m"
+    ContinuationPrompt = "`e[38;2;105;91;88m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;119;111;39m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;128;120;117m"
+    Keyword = "`e[38;2;82;79;44m"
+    ListPrediction = "`e[38;2;111;32;9m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;105;91;88m"
+    Member = "`e[38;2;90;58;39m"
+    Number = "`e[38;2;140;72;15m"
+    Operator = "`e[38;2;83;79;38m"
+    Parameter = "`e[38;2;48;93;44m"
+    Selection = "`e[7m"
+    String = "`e[38;2;134;15;19m"
+    Type = "`e[38;2;45;92;78m"
+    Variable = "`e[38;2;34;89;113m"
+}

--- a/extras/psreadline/themes/light/3/oasis_sol_light_3.ps1
+++ b/extras/psreadline/themes/light/3/oasis_sol_light_3.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_sol_light_3.ps1
+# name: Oasis Sol Light 3
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;162;35;39m"
+    Comment = "`e[3;38;2;105;84;82m"
+    ContinuationPrompt = "`e[38;2;100;86;84m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;49;115;43m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;116;116;116m"
+    Keyword = "`e[38;2;147;16;20m"
+    ListPrediction = "`e[38;2;112;60;8m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;100;86;84m"
+    Member = "`e[38;2;83;54;36m"
+    Number = "`e[38;2;132;68;14m"
+    Operator = "`e[38;2;142;27;32m"
+    Parameter = "`e[38;2;45;88;42m"
+    Selection = "`e[7m"
+    String = "`e[38;2;66;61;27m"
+    Type = "`e[38;2;43;86;74m"
+    Variable = "`e[38;2;32;84;106m"
+}

--- a/extras/psreadline/themes/light/3/oasis_starlight_light_3.ps1
+++ b/extras/psreadline/themes/light/3/oasis_starlight_light_3.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_starlight_light_3.ps1
+# name: Oasis Starlight Light 3
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;116;107;46m"
+    Comment = "`e[3;38;2;97;112;133m"
+    ContinuationPrompt = "`e[38;2;104;112;122m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;155;3;3m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;134;141;144m"
+    Keyword = "`e[38;2;107;93;47m"
+    ListPrediction = "`e[38;2;104;95;16m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;104;112;122m"
+    Member = "`e[38;2;112;73;49m"
+    Number = "`e[38;2;165;85;18m"
+    Operator = "`e[38;2;101;95;46m"
+    Parameter = "`e[38;2;58;112;53m"
+    Selection = "`e[7m"
+    String = "`e[38;2;164;18;23m"
+    Type = "`e[38;2;54;110;94m"
+    Variable = "`e[38;2;41;107;135m"
+}

--- a/extras/psreadline/themes/light/3/oasis_twilight_light_3.ps1
+++ b/extras/psreadline/themes/light/3/oasis_twilight_light_3.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_twilight_light_3.ps1
+# name: Oasis Twilight Light 3
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;171;61;28m"
+    Comment = "`e[3;38;2;106;97;126m"
+    ContinuationPrompt = "`e[38;2;104;99;118m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;137;126;21m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;131;128;138m"
+    Keyword = "`e[38;2;137;64;41m"
+    ListPrediction = "`e[38;2;54;2;117m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;104;99;118m"
+    Member = "`e[38;2;81;74;27m"
+    Number = "`e[38;2;151;78;16m"
+    Operator = "`e[38;2;150;53;25m"
+    Parameter = "`e[38;2;52;102;48m"
+    Selection = "`e[7m"
+    String = "`e[38;2;147;16;20m"
+    Type = "`e[38;2;49;100;85m"
+    Variable = "`e[38;2;37;97;122m"
+}

--- a/extras/psreadline/themes/light/4/oasis_abyss_light_4.ps1
+++ b/extras/psreadline/themes/light/4/oasis_abyss_light_4.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_abyss_light_4.ps1
+# name: Oasis Abyss Light 4
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;94;86;37m"
+    Comment = "`e[3;38;2;93;90;80m"
+    ContinuationPrompt = "`e[38;2;91;90;82m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;45;108;39m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;118;117;112m"
+    Keyword = "`e[38;2;79;74;41m"
+    ListPrediction = "`e[38;2;109;1;1m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;91;90;82m"
+    Member = "`e[38;2;85;54;37m"
+    Number = "`e[38;2;133;68;14m"
+    Operator = "`e[38;2;79;74;36m"
+    Parameter = "`e[38;2;45;89;42m"
+    Selection = "`e[7m"
+    String = "`e[38;2;125;14;18m"
+    Type = "`e[38;2;43;87;73m"
+    Variable = "`e[38;2;32;85;107m"
+}

--- a/extras/psreadline/themes/light/4/oasis_cactus_light_4.ps1
+++ b/extras/psreadline/themes/light/4/oasis_cactus_light_4.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_cactus_light_4.ps1
+# name: Oasis Cactus Light 4
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;64;108;66m"
+    Comment = "`e[3;38;2;87;108;88m"
+    ContinuationPrompt = "`e[38;2;94;105;96m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;146;1;1m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;124;133;126m"
+    Keyword = "`e[38;2;56;95;58m"
+    ListPrediction = "`e[38;2;50;1;109m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;94;105;96m"
+    Member = "`e[38;2;102;65;44m"
+    Number = "`e[38;2;153;78;17m"
+    Operator = "`e[38;2;54;95;57m"
+    Parameter = "`e[38;2;119;86;17m"
+    Selection = "`e[7m"
+    String = "`e[38;2;149;16;21m"
+    Type = "`e[38;2;50;101;85m"
+    Variable = "`e[38;2;38;98;123m"
+}

--- a/extras/psreadline/themes/light/4/oasis_canyon_light_4.ps1
+++ b/extras/psreadline/themes/light/4/oasis_canyon_light_4.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_canyon_light_4.ps1
+# name: Oasis Canyon Light 4
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;151;54;26m"
+    Comment = "`e[3;38;2;114;83;70m"
+    ContinuationPrompt = "`e[38;2;104;87;78m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;146;1;1m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;121;116;113m"
+    Keyword = "`e[38;2;118;56;36m"
+    ListPrediction = "`e[38;2;2;62;108m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;104;87;78m"
+    Member = "`e[38;2;68;62;23m"
+    Number = "`e[38;2;134;68;15m"
+    Operator = "`e[38;2;131;47;23m"
+    Parameter = "`e[38;2;46;89;43m"
+    Selection = "`e[7m"
+    String = "`e[38;2;126;14;18m"
+    Type = "`e[38;2;43;88;74m"
+    Variable = "`e[38;2;33;85;107m"
+}

--- a/extras/psreadline/themes/light/4/oasis_desert_light_4.ps1
+++ b/extras/psreadline/themes/light/4/oasis_desert_light_4.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_desert_light_4.ps1
+# name: Oasis Desert Light 4
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;112;101;27m"
+    Comment = "`e[3;38;2;108;104;93m"
+    ContinuationPrompt = "`e[38;2;106;104;96m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;45;108;39m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;134;133;127m"
+    Keyword = "`e[38;2;94;89;49m"
+    ListPrediction = "`e[38;2;109;1;1m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;106;104;96m"
+    Member = "`e[38;2;104;67;46m"
+    Number = "`e[38;2;156;80;17m"
+    Operator = "`e[38;2;96;88;38m"
+    Parameter = "`e[38;2;54;105;50m"
+    Selection = "`e[7m"
+    String = "`e[38;2;153;17;22m"
+    Type = "`e[38;2;51;103;87m"
+    Variable = "`e[38;2;38;100;126m"
+}

--- a/extras/psreadline/themes/light/4/oasis_dune_light_4.ps1
+++ b/extras/psreadline/themes/light/4/oasis_dune_light_4.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_dune_light_4.ps1
+# name: Oasis Dune Light 4
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;110;99;27m"
+    Comment = "`e[3;38;2;113;100;91m"
+    ContinuationPrompt = "`e[38;2;111;101;92m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;43;105;88m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;135;130;125m"
+    Keyword = "`e[38;2;92;87;48m"
+    ListPrediction = "`e[38;2;85;48;24m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;111;101;92m"
+    Member = "`e[38;2;102;65;44m"
+    Number = "`e[38;2;153;78;17m"
+    Operator = "`e[38;2;94;87;38m"
+    Parameter = "`e[38;2;53;103;49m"
+    Selection = "`e[7m"
+    String = "`e[38;2;149;16;21m"
+    Type = "`e[38;2;50;101;85m"
+    Variable = "`e[38;2;38;98;124m"
+}

--- a/extras/psreadline/themes/light/4/oasis_lagoon_light_4.ps1
+++ b/extras/psreadline/themes/light/4/oasis_lagoon_light_4.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_lagoon_light_4.ps1
+# name: Oasis Lagoon Light 4
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;20;94;183m"
+    Comment = "`e[3;38;2;75;103;122m"
+    ContinuationPrompt = "`e[38;2;84;102;114m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;146;1;1m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;123;129;133m"
+    Keyword = "`e[38;2;17;85;144m"
+    ListPrediction = "`e[38;2;104;54;6m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;84;102;114m"
+    Member = "`e[38;2;98;63;43m"
+    Number = "`e[38;2;149;76;16m"
+    Operator = "`e[38;2;17;82;161m"
+    Parameter = "`e[38;2;51;100;48m"
+    Selection = "`e[7m"
+    String = "`e[38;2;144;16;20m"
+    Type = "`e[38;2;100;89;27m"
+    Variable = "`e[38;2;35;96;119m"
+}

--- a/extras/psreadline/themes/light/4/oasis_luna_light_4.ps1
+++ b/extras/psreadline/themes/light/4/oasis_luna_light_4.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_luna_light_4.ps1
+# name: Oasis Luna Light 4
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;99;91;39m"
+    Comment = "`e[3;38;2;98;88;131m"
+    ContinuationPrompt = "`e[38;2;94;92;110m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;19;104;129m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;122;120;131m"
+    Keyword = "`e[38;2;84;79;44m"
+    ListPrediction = "`e[38;2;20;20;90m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;94;92;110m"
+    Member = "`e[38;2;91;58;40m"
+    Number = "`e[38;2;140;72;15m"
+    Operator = "`e[38;2;84;79;38m"
+    Parameter = "`e[38;2;48;94;45m"
+    Selection = "`e[7m"
+    String = "`e[38;2;134;15;19m"
+    Type = "`e[38;2;46;92;78m"
+    Variable = "`e[38;2;34;89;113m"
+}

--- a/extras/psreadline/themes/light/4/oasis_midnight_light_4.ps1
+++ b/extras/psreadline/themes/light/4/oasis_midnight_light_4.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_midnight_light_4.ps1
+# name: Oasis Midnight Light 4
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;98;90;39m"
+    Comment = "`e[3;38;2;83;94;111m"
+    ContinuationPrompt = "`e[38;2;86;94;101m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;45;108;39m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;115;121;126m"
+    Keyword = "`e[38;2;83;78;43m"
+    ListPrediction = "`e[38;2;109;1;1m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;86;94;101m"
+    Member = "`e[38;2;89;57;39m"
+    Number = "`e[38;2;138;71;15m"
+    Operator = "`e[38;2;82;78;38m"
+    Parameter = "`e[38;2;47;93;44m"
+    Selection = "`e[7m"
+    String = "`e[38;2;132;14;19m"
+    Type = "`e[38;2;45;91;77m"
+    Variable = "`e[38;2;34;88;111m"
+}

--- a/extras/psreadline/themes/light/4/oasis_mirage_light_4.ps1
+++ b/extras/psreadline/themes/light/4/oasis_mirage_light_4.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_mirage_light_4.ps1
+# name: Oasis Mirage Light 4
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;53;110;94m"
+    Comment = "`e[3;38;2;67;112;104m"
+    ContinuationPrompt = "`e[38;2;94;107;106m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;67;1;146m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;127;134;134m"
+    Keyword = "`e[38;2;50;96;84m"
+    ListPrediction = "`e[38;2;104;54;6m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;94;107;106m"
+    Member = "`e[38;2;104;67;46m"
+    Number = "`e[38;2;155;79;17m"
+    Operator = "`e[38;2;46;97;81m"
+    Parameter = "`e[38;2;54;105;50m"
+    Selection = "`e[7m"
+    String = "`e[38;2;152;17;22m"
+    Type = "`e[38;2;105;94;28m"
+    Variable = "`e[38;2;38;100;126m"
+}

--- a/extras/psreadline/themes/light/4/oasis_moonlight_light_4.ps1
+++ b/extras/psreadline/themes/light/4/oasis_moonlight_light_4.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_moonlight_light_4.ps1
+# name: Oasis Moonlight Light 4
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;104;95;41m"
+    Comment = "`e[3;38;2;88;100;118m"
+    ContinuationPrompt = "`e[38;2;91;100;108m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;146;1;1m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;123;127;132m"
+    Keyword = "`e[38;2;88;83;46m"
+    ListPrediction = "`e[38;2;96;88;13m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;91;100;108m"
+    Member = "`e[38;2;97;62;42m"
+    Number = "`e[38;2;147;75;16m"
+    Operator = "`e[38;2;88;83;40m"
+    Parameter = "`e[38;2;50;99;47m"
+    Selection = "`e[7m"
+    String = "`e[38;2;142;15;20m"
+    Type = "`e[38;2;48;97;82m"
+    Variable = "`e[38;2;36;95;119m"
+}

--- a/extras/psreadline/themes/light/4/oasis_night_light_4.ps1
+++ b/extras/psreadline/themes/light/4/oasis_night_light_4.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_night_light_4.ps1
+# name: Oasis Night Light 4
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;99;91;39m"
+    Comment = "`e[3;38;2;82;96;113m"
+    ContinuationPrompt = "`e[38;2;87;95;103m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;146;1;1m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;118;123;127m"
+    Keyword = "`e[38;2;84;79;44m"
+    ListPrediction = "`e[38;2;96;88;13m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;87;95;103m"
+    Member = "`e[38;2;91;58;40m"
+    Number = "`e[38;2;140;72;15m"
+    Operator = "`e[38;2;84;79;38m"
+    Parameter = "`e[38;2;48;94;45m"
+    Selection = "`e[7m"
+    String = "`e[38;2;134;15;19m"
+    Type = "`e[38;2;46;92;78m"
+    Variable = "`e[38;2;34;90;113m"
+}

--- a/extras/psreadline/themes/light/4/oasis_rose_light_4.ps1
+++ b/extras/psreadline/themes/light/4/oasis_rose_light_4.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_rose_light_4.ps1
+# name: Oasis Rose Light 4
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;150;54;92m"
+    Comment = "`e[3;38;2;113;85;99m"
+    ContinuationPrompt = "`e[38;2;103;89;97m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;42;106;87m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;124;118;122m"
+    Keyword = "`e[38;2;126;50;79m"
+    ListPrediction = "`e[38;2;38;72;39m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;103;89;97m"
+    Member = "`e[38;2;89;57;39m"
+    Number = "`e[38;2;138;70;15m"
+    Operator = "`e[38;2;126;50;79m"
+    Parameter = "`e[38;2;47;92;44m"
+    Selection = "`e[7m"
+    String = "`e[38;2;131;14;18m"
+    Type = "`e[38;2;45;90;76m"
+    Variable = "`e[38;2;34;88;111m"
+}

--- a/extras/psreadline/themes/light/4/oasis_scorpion_light_4.ps1
+++ b/extras/psreadline/themes/light/4/oasis_scorpion_light_4.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_scorpion_light_4.ps1
+# name: Oasis Scorpion Light 4
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;93;85;37m"
+    Comment = "`e[3;38;2;107;84;79m"
+    ContinuationPrompt = "`e[38;2;99;86;83m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;113;105;35m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;121;115;113m"
+    Keyword = "`e[38;2;78;73;41m"
+    ListPrediction = "`e[38;2;102;29;7m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;99;86;83m"
+    Member = "`e[38;2;84;54;36m"
+    Number = "`e[38;2;132;67;14m"
+    Operator = "`e[38;2;78;73;36m"
+    Parameter = "`e[38;2;45;88;42m"
+    Selection = "`e[7m"
+    String = "`e[38;2;124;13;17m"
+    Type = "`e[38;2;43;86;73m"
+    Variable = "`e[38;2;32;84;106m"
+}

--- a/extras/psreadline/themes/light/4/oasis_sol_light_4.ps1
+++ b/extras/psreadline/themes/light/4/oasis_sol_light_4.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_sol_light_4.ps1
+# name: Oasis Sol Light 4
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;150;32;36m"
+    Comment = "`e[3;38;2;96;78;75m"
+    ContinuationPrompt = "`e[38;2;93;79;77m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;45;108;39m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;109;109;109m"
+    Keyword = "`e[38;2;134;15;19m"
+    ListPrediction = "`e[38;2;104;54;6m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;93;79;77m"
+    Member = "`e[38;2;74;48;32m"
+    Number = "`e[38;2;122;62;13m"
+    Operator = "`e[38;2;129;26;29m"
+    Parameter = "`e[38;2;41;81;39m"
+    Selection = "`e[7m"
+    String = "`e[38;2;59;54;23m"
+    Type = "`e[38;2;39;79;67m"
+    Variable = "`e[38;2;29;77;97m"
+}

--- a/extras/psreadline/themes/light/4/oasis_starlight_light_4.ps1
+++ b/extras/psreadline/themes/light/4/oasis_starlight_light_4.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_starlight_light_4.ps1
+# name: Oasis Starlight Light 4
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;113;104;45m"
+    Comment = "`e[3;38;2;93;109;128m"
+    ContinuationPrompt = "`e[38;2;101;108;117m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;146;1;1m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;130;138;139m"
+    Keyword = "`e[38;2;103;90;45m"
+    ListPrediction = "`e[38;2;96;88;13m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;101;108;117m"
+    Member = "`e[38;2;108;69;47m"
+    Number = "`e[38;2;160;82;17m"
+    Operator = "`e[38;2;97;92;44m"
+    Parameter = "`e[38;2;55;108;52m"
+    Selection = "`e[7m"
+    String = "`e[38;2;158;17;22m"
+    Type = "`e[38;2;52;106;89m"
+    Variable = "`e[38;2;39;103;130m"
+}

--- a/extras/psreadline/themes/light/4/oasis_twilight_light_4.ps1
+++ b/extras/psreadline/themes/light/4/oasis_twilight_light_4.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_twilight_light_4.ps1
+# name: Oasis Twilight Light 4
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;160;57;28m"
+    Comment = "`e[3;38;2;99;92;118m"
+    ContinuationPrompt = "`e[38;2;98;93;110m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;130;119;18m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;124;122;131m"
+    Keyword = "`e[38;2;127;60;39m"
+    ListPrediction = "`e[38;2;50;1;109m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;98;93;110m"
+    Member = "`e[38;2;74;68;25m"
+    Number = "`e[38;2;142;73;15m"
+    Operator = "`e[38;2;140;50;24m"
+    Parameter = "`e[38;2;49;96;46m"
+    Selection = "`e[7m"
+    String = "`e[38;2;136;15;19m"
+    Type = "`e[38;2;46;94;79m"
+    Variable = "`e[38;2;35;91;114m"
+}

--- a/extras/psreadline/themes/light/5/oasis_abyss_light_5.ps1
+++ b/extras/psreadline/themes/light/5/oasis_abyss_light_5.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_abyss_light_5.ps1
+# name: Oasis Abyss Light 5
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;89;82;35m"
+    Comment = "`e[3;38;2;88;85;75m"
+    ContinuationPrompt = "`e[38;2;88;85;78m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;41;102;36m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;113;112;106m"
+    Keyword = "`e[38;2;73;70;39m"
+    ListPrediction = "`e[38;2;99;0;0m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;88;85;78m"
+    Member = "`e[38;2;78;50;34m"
+    Number = "`e[38;2;127;64;14m"
+    Operator = "`e[38;2;74;70;34m"
+    Parameter = "`e[38;2;43;84;39m"
+    Selection = "`e[7m"
+    String = "`e[38;2;116;13;17m"
+    Type = "`e[38;2;41;82;70m"
+    Variable = "`e[38;2;30;80;100m"
+}

--- a/extras/psreadline/themes/light/5/oasis_cactus_light_5.ps1
+++ b/extras/psreadline/themes/light/5/oasis_cactus_light_5.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_cactus_light_5.ps1
+# name: Oasis Cactus Light 5
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;61;104;63m"
+    Comment = "`e[3;38;2;82;104;84m"
+    ContinuationPrompt = "`e[38;2;90;101;93m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;138;0;0m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;120;128;123m"
+    Keyword = "`e[38;2;53;90;55m"
+    ListPrediction = "`e[38;2;45;0;99m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;90;101;93m"
+    Member = "`e[38;2;96;62;42m"
+    Number = "`e[38;2;147;74;16m"
+    Operator = "`e[38;2;53;90;55m"
+    Parameter = "`e[38;2;113;82;16m"
+    Selection = "`e[7m"
+    String = "`e[38;2;142;15;20m"
+    Type = "`e[38;2;48;96;82m"
+    Variable = "`e[38;2;35;94;118m"
+}

--- a/extras/psreadline/themes/light/5/oasis_canyon_light_5.ps1
+++ b/extras/psreadline/themes/light/5/oasis_canyon_light_5.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_canyon_light_5.ps1
+# name: Oasis Canyon Light 5
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;143;51;24m"
+    Comment = "`e[3;38;2;108;79;67m"
+    ContinuationPrompt = "`e[38;2;99;82;74m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;138;0;0m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;117;111;108m"
+    Keyword = "`e[38;2;111;52;33m"
+    ListPrediction = "`e[38;2;1;56;99m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;99;82;74m"
+    Member = "`e[38;2;64;58;21m"
+    Number = "`e[38;2;127;64;14m"
+    Operator = "`e[38;2;123;43;20m"
+    Parameter = "`e[38;2;44;84;40m"
+    Selection = "`e[7m"
+    String = "`e[38;2;117;13;17m"
+    Type = "`e[38;2;41;83;71m"
+    Variable = "`e[38;2;30;81;101m"
+}

--- a/extras/psreadline/themes/light/5/oasis_desert_light_5.ps1
+++ b/extras/psreadline/themes/light/5/oasis_desert_light_5.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_desert_light_5.ps1
+# name: Oasis Desert Light 5
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;108;98;26m"
+    Comment = "`e[3;38;2;105;102;90m"
+    ContinuationPrompt = "`e[38;2;105;102;93m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;41;102;36m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;131;130;124m"
+    Keyword = "`e[38;2;91;86;48m"
+    ListPrediction = "`e[38;2;99;0;0m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;105;102;93m"
+    Member = "`e[38;2;100;65;44m"
+    Number = "`e[38;2;152;77;17m"
+    Operator = "`e[38;2;93;86;37m"
+    Parameter = "`e[38;2;53;102;48m"
+    Selection = "`e[7m"
+    String = "`e[38;2;148;16;21m"
+    Type = "`e[38;2;50;100;85m"
+    Variable = "`e[38;2;36;98;122m"
+}

--- a/extras/psreadline/themes/light/5/oasis_dune_light_5.ps1
+++ b/extras/psreadline/themes/light/5/oasis_dune_light_5.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_dune_light_5.ps1
+# name: Oasis Dune Light 5
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;105;95;26m"
+    Comment = "`e[3;38;2;109;97;89m"
+    ContinuationPrompt = "`e[38;2;106;98;89m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;39;98;82m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;132;126;121m"
+    Keyword = "`e[38;2;88;84;47m"
+    ListPrediction = "`e[38;2;78;44;22m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;106;98;89m"
+    Member = "`e[38;2;97;63;42m"
+    Number = "`e[38;2;148;75;16m"
+    Operator = "`e[38;2;90;83;36m"
+    Parameter = "`e[38;2;51;99;47m"
+    Selection = "`e[7m"
+    String = "`e[38;2;143;15;21m"
+    Type = "`e[38;2;49;97;83m"
+    Variable = "`e[38;2;35;95;119m"
+}

--- a/extras/psreadline/themes/light/5/oasis_lagoon_light_5.ps1
+++ b/extras/psreadline/themes/light/5/oasis_lagoon_light_5.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_lagoon_light_5.ps1
+# name: Oasis Lagoon Light 5
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;19;88;174m"
+    Comment = "`e[3;38;2;71;98;114m"
+    ContinuationPrompt = "`e[38;2;79;97;107m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;138;0;0m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;116;123;126m"
+    Keyword = "`e[38;2;17;80;136m"
+    ListPrediction = "`e[38;2;95;49;5m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;79;97;107m"
+    Member = "`e[38;2;91;59;40m"
+    Number = "`e[38;2;141;71;15m"
+    Operator = "`e[38;2;16;77;151m"
+    Parameter = "`e[38;2;49;94;44m"
+    Selection = "`e[7m"
+    String = "`e[38;2;134;15;19m"
+    Type = "`e[38;2;94;84;25m"
+    Variable = "`e[38;2;33;90;112m"
+}

--- a/extras/psreadline/themes/light/5/oasis_luna_light_5.ps1
+++ b/extras/psreadline/themes/light/5/oasis_luna_light_5.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_luna_light_5.ps1
+# name: Oasis Luna Light 5
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;90;83;36m"
+    Comment = "`e[3;38;2;89;81;121m"
+    ContinuationPrompt = "`e[38;2;87;85;101m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;17;97;121m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;114;112;121m"
+    Keyword = "`e[38;2;75;71;40m"
+    ListPrediction = "`e[38;2;17;17;82m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;87;85;101m"
+    Member = "`e[38;2;80;52;35m"
+    Number = "`e[38;2;129;65;14m"
+    Operator = "`e[38;2;76;71;35m"
+    Parameter = "`e[38;2;44;85;40m"
+    Selection = "`e[7m"
+    String = "`e[38;2;119;13;17m"
+    Type = "`e[38;2;42;84;72m"
+    Variable = "`e[38;2;30;82;102m"
+}

--- a/extras/psreadline/themes/light/5/oasis_midnight_light_5.ps1
+++ b/extras/psreadline/themes/light/5/oasis_midnight_light_5.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_midnight_light_5.ps1
+# name: Oasis Midnight Light 5
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;91;84;36m"
+    Comment = "`e[3;38;2;78;88;102m"
+    ContinuationPrompt = "`e[38;2;81;89;95m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;41;102;36m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;110;115;119m"
+    Keyword = "`e[38;2;76;72;41m"
+    ListPrediction = "`e[38;2;99;0;0m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;81;89;95m"
+    Member = "`e[38;2;81;53;35m"
+    Number = "`e[38;2;131;66;14m"
+    Operator = "`e[38;2;77;72;35m"
+    Parameter = "`e[38;2;45;86;41m"
+    Selection = "`e[7m"
+    String = "`e[38;2;121;13;17m"
+    Type = "`e[38;2;42;85;72m"
+    Variable = "`e[38;2;31;83;104m"
+}

--- a/extras/psreadline/themes/light/5/oasis_mirage_light_5.ps1
+++ b/extras/psreadline/themes/light/5/oasis_mirage_light_5.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_mirage_light_5.ps1
+# name: Oasis Mirage Light 5
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;49;107;90m"
+    Comment = "`e[3;38;2;65;109;102m"
+    ContinuationPrompt = "`e[38;2;91;103;102m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;62;0;138m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;123;131;131m"
+    Keyword = "`e[38;2;47;92;80m"
+    ListPrediction = "`e[38;2;95;49;5m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;91;103;102m"
+    Member = "`e[38;2;99;64;43m"
+    Number = "`e[38;2;151;76;16m"
+    Operator = "`e[38;2;44;93;80m"
+    Parameter = "`e[38;2;52;101;48m"
+    Selection = "`e[7m"
+    String = "`e[38;2;146;16;21m"
+    Type = "`e[38;2;101;91;27m"
+    Variable = "`e[38;2;36;97;121m"
+}

--- a/extras/psreadline/themes/light/5/oasis_moonlight_light_5.ps1
+++ b/extras/psreadline/themes/light/5/oasis_moonlight_light_5.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_moonlight_light_5.ps1
+# name: Oasis Moonlight Light 5
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;99;91;40m"
+    Comment = "`e[3;38;2;84;96;111m"
+    ContinuationPrompt = "`e[38;2;87;96;102m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;138;0;0m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;118;123;127m"
+    Keyword = "`e[38;2;83;79;45m"
+    ListPrediction = "`e[38;2;88;80;11m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;87;96;102m"
+    Member = "`e[38;2;91;59;40m"
+    Number = "`e[38;2;142;72;15m"
+    Operator = "`e[38;2;85;79;39m"
+    Parameter = "`e[38;2;49;94;44m"
+    Selection = "`e[7m"
+    String = "`e[38;2;134;15;19m"
+    Type = "`e[38;2;46;92;79m"
+    Variable = "`e[38;2;34;90;113m"
+}

--- a/extras/psreadline/themes/light/5/oasis_night_light_5.ps1
+++ b/extras/psreadline/themes/light/5/oasis_night_light_5.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_night_light_5.ps1
+# name: Oasis Night Light 5
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;94;87;38m"
+    Comment = "`e[3;38;2;79;92;108m"
+    ContinuationPrompt = "`e[38;2;83;91;100m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;138;0;0m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;113;118;122m"
+    Keyword = "`e[38;2;79;75;42m"
+    ListPrediction = "`e[38;2;88;80;11m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;83;91;100m"
+    Member = "`e[38;2;85;55;37m"
+    Number = "`e[38;2;135;68;15m"
+    Operator = "`e[38;2;80;75;37m"
+    Parameter = "`e[38;2;46;89;42m"
+    Selection = "`e[7m"
+    String = "`e[38;2;127;14;18m"
+    Type = "`e[38;2;44;88;75m"
+    Variable = "`e[38;2;32;86;107m"
+}

--- a/extras/psreadline/themes/light/5/oasis_rose_light_5.ps1
+++ b/extras/psreadline/themes/light/5/oasis_rose_light_5.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_rose_light_5.ps1
+# name: Oasis Rose Light 5
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;140;49;86m"
+    Comment = "`e[3;38;2;104;79;92m"
+    ContinuationPrompt = "`e[38;2;95;83;91m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;38;100;81m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;119;111;116m"
+    Keyword = "`e[38;2;116;46;74m"
+    ListPrediction = "`e[38;2;34;65;35m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;95;83;91m"
+    Member = "`e[38;2;80;52;35m"
+    Number = "`e[38;2;129;65;14m"
+    Operator = "`e[38;2;116;46;74m"
+    Parameter = "`e[38;2;44;85;40m"
+    Selection = "`e[7m"
+    String = "`e[38;2;119;13;17m"
+    Type = "`e[38;2;42;84;71m"
+    Variable = "`e[38;2;30;82;102m"
+}

--- a/extras/psreadline/themes/light/5/oasis_scorpion_light_5.ps1
+++ b/extras/psreadline/themes/light/5/oasis_scorpion_light_5.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_scorpion_light_5.ps1
+# name: Oasis Scorpion Light 5
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;86;79;34m"
+    Comment = "`e[3;38;2;100;78;73m"
+    ContinuationPrompt = "`e[38;2;92;80;79m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;106;98;32m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;114;108;105m"
+    Keyword = "`e[38;2;71;68;38m"
+    ListPrediction = "`e[38;2;94;26;6m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;92;80;79m"
+    Member = "`e[38;2;75;49;33m"
+    Number = "`e[38;2;123;62;13m"
+    Operator = "`e[38;2;72;67;33m"
+    Parameter = "`e[38;2;42;81;38m"
+    Selection = "`e[7m"
+    String = "`e[38;2;112;12;16m"
+    Type = "`e[38;2;40;80;68m"
+    Variable = "`e[38;2;29;78;98m"
+}

--- a/extras/psreadline/themes/light/5/oasis_sol_light_5.ps1
+++ b/extras/psreadline/themes/light/5/oasis_sol_light_5.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_sol_light_5.ps1
+# name: Oasis Sol Light 5
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;137;31;33m"
+    Comment = "`e[3;38;2;89;72;70m"
+    ContinuationPrompt = "`e[38;2;85;73;71m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;41;102;36m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;102;102;102m"
+    Keyword = "`e[38;2;122;13;18m"
+    ListPrediction = "`e[38;2;95;49;5m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;85;73;71m"
+    Member = "`e[38;2;65;42;28m"
+    Number = "`e[38;2;113;57;12m"
+    Operator = "`e[38;2;117;23;26m"
+    Parameter = "`e[38;2;38;73;34m"
+    Selection = "`e[7m"
+    String = "`e[38;2;51;47;21m"
+    Type = "`e[38;2;36;72;61m"
+    Variable = "`e[38;2;26;70;88m"
+}

--- a/extras/psreadline/themes/light/5/oasis_starlight_light_5.ps1
+++ b/extras/psreadline/themes/light/5/oasis_starlight_light_5.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_starlight_light_5.ps1
+# name: Oasis Starlight Light 5
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;108;100;43m"
+    Comment = "`e[3;38;2;90;104;123m"
+    ContinuationPrompt = "`e[38;2;96;104;113m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;138;0;0m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;125;133;135m"
+    Keyword = "`e[38;2;98;86;43m"
+    ListPrediction = "`e[38;2;88;80;11m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;96;104;113m"
+    Member = "`e[38;2;102;66;45m"
+    Number = "`e[38;2;154;78;17m"
+    Operator = "`e[38;2;93;87;43m"
+    Parameter = "`e[38;2;53;103;48m"
+    Selection = "`e[7m"
+    String = "`e[38;2;150;16;22m"
+    Type = "`e[38;2;51;101;87m"
+    Variable = "`e[38;2;37;99;124m"
+}

--- a/extras/psreadline/themes/light/5/oasis_twilight_light_5.ps1
+++ b/extras/psreadline/themes/light/5/oasis_twilight_light_5.ps1
@@ -1,0 +1,25 @@
+# extras/psreadline/themes/.../oasis_twilight_light_5.ps1
+# name: Oasis Twilight Light 5
+# author: uhs-robert
+
+Set-PSReadLineOption -Colors @{
+    Command = "`e[38;2;149;53;25m"
+    Comment = "`e[3;38;2;94;85;111m"
+    ContinuationPrompt = "`e[38;2;91;87;102m"
+    Default = "`e[38;2;24;24;17m"
+    Emphasis = "`e[38;2;122;111;16m"
+    Error = "`e[38;2;112;24;24m"
+    InlinePrediction = "`e[3;38;2;118;115;124m"
+    Keyword = "`e[38;2;117;55;35m"
+    ListPrediction = "`e[38;2;45;0;99m"
+    ListPredictionSelected = "`e[7m"
+    ListPredictionTooltip = "`e[38;2;91;87;102m"
+    Member = "`e[38;2;67;61;22m"
+    Number = "`e[38;2;133;67;14m"
+    Operator = "`e[38;2;129;46;21m"
+    Parameter = "`e[38;2;46;88;41m"
+    Selection = "`e[7m"
+    String = "`e[38;2;124;13;18m"
+    Type = "`e[38;2;43;86;74m"
+    Variable = "`e[38;2;31;84;106m"
+}

--- a/extras/windows-terminal/README.md
+++ b/extras/windows-terminal/README.md
@@ -1,0 +1,42 @@
+# Windows Terminal Setup
+
+1. Open Windows Terminal's `settings.json` (Settings > Open JSON file).
+2. Copy the contents of your chosen theme file into the `"schemes"` array.
+3. Set `"colorScheme"` in your profile to the scheme's `"name"` value.
+
+### Example
+
+```json
+{
+  "schemes": [
+    {
+      "name": "Oasis Lagoon Dark",
+      "background": "#101825",
+      "foreground": "#F5F5DC",
+      "selectionBackground": "#22385C",
+      "cursorColor": "#F0E68C",
+      "black": "#101825",
+      "red": "#FF7979",
+      "green": "#7FCF78",
+      "yellow": "#F0E68C",
+      "blue": "#81C0FF",
+      "purple": "#C695FF",
+      "cyan": "#69C3AA",
+      "white": "#F5F5DC",
+      "brightBlack": "#3B6A87",
+      "brightRed": "#FFA0A0",
+      "brightGreen": "#A3E39A",
+      "brightYellow": "#F8B471",
+      "brightBlue": "#87CEEB",
+      "brightPurple": "#D2ADFF",
+      "brightCyan": "#8AD3BE",
+      "brightWhite": "#FFFFF0"
+    }
+  ],
+  "profiles": {
+    "defaults": {
+      "colorScheme": "Oasis Lagoon Dark"
+    }
+  }
+}
+```

--- a/extras/windows-terminal/generate_windowsterminal.lua
+++ b/extras/windows-terminal/generate_windowsterminal.lua
@@ -1,0 +1,79 @@
+#!/usr/bin/env lua
+-- extras/windows-terminal/generate_windowsterminal.lua
+-- Generates Windows Terminal color scheme JSON objects from Oasis color palettes
+
+-- Load shared utilities
+package.path = package.path .. ";./lua/?.lua;./lua/?/init.lua"
+local Utils = require("oasis.utils")
+local File = require("oasis.lib.file")
+local ColorUtils = require("oasis.tools.color_utils")
+
+local function generate_windows_terminal_theme(name, palette)
+  local display_name = Utils.format_display_name(name)
+  local is_light = palette.light_mode or false
+
+  -- stylua: ignore
+  local fields = {
+    { "name",                 display_name },
+    { "background",           palette.bg.core },
+    { "foreground",           palette.fg.core },
+    { "selectionBackground",  palette.ui.visual.bg },
+    { "cursorColor",          is_light and palette.syntax.statement or palette.theme.cursor },
+    { "black",                palette.terminal.black },
+    { "red",                  palette.terminal.red },
+    { "green",                palette.terminal.green },
+    { "yellow",               palette.terminal.yellow },
+    { "blue",                 palette.terminal.blue },
+    { "purple",               palette.terminal.magenta },
+    { "cyan",                 palette.terminal.cyan },
+    { "white",                palette.terminal.white },
+    { "brightBlack",          palette.terminal.bright_black },
+    { "brightRed",            palette.terminal.bright_red },
+    { "brightGreen",          palette.terminal.bright_green },
+    { "brightYellow",         palette.terminal.bright_yellow },
+    { "brightBlue",           palette.terminal.bright_blue },
+    { "brightPurple",         palette.terminal.bright_magenta },
+    { "brightCyan",           palette.terminal.bright_cyan },
+    { "brightWhite",          palette.terminal.bright_white },
+  }
+  -- stylua: on
+
+  local lines = { "{" }
+  for i, field in ipairs(fields) do
+    local comma = i < #fields and "," or ""
+    lines[#lines + 1] = string.format('  "%s": "%s"%s', field[1], ColorUtils.json_escape(field[2]), comma)
+  end
+  lines[#lines + 1] = "}"
+
+  return table.concat(lines, "\n")
+end
+
+local function main()
+  print("\n=== Oasis Windows Terminal Theme Generator ===\n")
+
+  local palette_names = Utils.get_palette_names()
+
+  if #palette_names == 0 then
+    print("Error: No palette files found in lua/oasis/color_palettes/")
+    return
+  end
+
+  print(string.format("Found %d palette(s)\n", #palette_names))
+
+  local success_count, error_count = Utils.for_each_palette_variant(function(name, palette, mode, intensity)
+    -- Build output path using shared utility
+    local output_path, variant_name = Utils.build_variant_path("extras/windows-terminal", "json", name, mode, intensity)
+
+    -- Generate and write theme
+    local theme = generate_windows_terminal_theme(variant_name, palette)
+    File.write(output_path, theme)
+    print(string.format("✓ Generated: %s", output_path))
+  end)
+
+  print(string.format("\n=== Summary ==="))
+  print(string.format("Success: %d", success_count))
+  print(string.format("Errors: %d\n", error_count))
+end
+
+-- Run the generator
+main()

--- a/extras/windows-terminal/themes/dark/oasis_abyss_dark.json
+++ b/extras/windows-terminal/themes/dark/oasis_abyss_dark.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Abyss Dark",
+  "background": "#000000",
+  "foreground": "#F5F5DC",
+  "selectionBackground": "#532E2E",
+  "cursorColor": "#F0E68C",
+  "black": "#000000",
+  "red": "#FF7979",
+  "green": "#7FCF78",
+  "yellow": "#F0E68C",
+  "blue": "#81C0FF",
+  "purple": "#C695FF",
+  "cyan": "#69C3AA",
+  "white": "#F5F5DC",
+  "brightBlack": "#605C4D",
+  "brightRed": "#FFA0A0",
+  "brightGreen": "#A3E39A",
+  "brightYellow": "#F8B471",
+  "brightBlue": "#87CEEB",
+  "brightPurple": "#D2ADFF",
+  "brightCyan": "#8AD3BE",
+  "brightWhite": "#FFFFF0"
+}

--- a/extras/windows-terminal/themes/dark/oasis_cactus_dark.json
+++ b/extras/windows-terminal/themes/dark/oasis_cactus_dark.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Cactus Dark",
+  "background": "#151E17",
+  "foreground": "#F5F5DC",
+  "selectionBackground": "#2F3D33",
+  "cursorColor": "#F0E68C",
+  "black": "#151E17",
+  "red": "#FF7979",
+  "green": "#7FCF78",
+  "yellow": "#F0E68C",
+  "blue": "#81C0FF",
+  "purple": "#C695FF",
+  "cyan": "#69C3AA",
+  "white": "#F5F5DC",
+  "brightBlack": "#5B7360",
+  "brightRed": "#FFA0A0",
+  "brightGreen": "#A3E39A",
+  "brightYellow": "#F8B471",
+  "brightBlue": "#87CEEB",
+  "brightPurple": "#D2ADFF",
+  "brightCyan": "#8AD3BE",
+  "brightWhite": "#FFFFF0"
+}

--- a/extras/windows-terminal/themes/dark/oasis_canyon_dark.json
+++ b/extras/windows-terminal/themes/dark/oasis_canyon_dark.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Canyon Dark",
+  "background": "#261612",
+  "foreground": "#F5F5DC",
+  "selectionBackground": "#483228",
+  "cursorColor": "#F0E68C",
+  "black": "#261612",
+  "red": "#FF7979",
+  "green": "#7FCF78",
+  "yellow": "#F0E68C",
+  "blue": "#81C0FF",
+  "purple": "#C695FF",
+  "cyan": "#69C3AA",
+  "white": "#F5F5DC",
+  "brightBlack": "#9A6549",
+  "brightRed": "#FFA0A0",
+  "brightGreen": "#A3E39A",
+  "brightYellow": "#F8B471",
+  "brightBlue": "#87CEEB",
+  "brightPurple": "#D2ADFF",
+  "brightCyan": "#8AD3BE",
+  "brightWhite": "#FFFFF0"
+}

--- a/extras/windows-terminal/themes/dark/oasis_desert_dark.json
+++ b/extras/windows-terminal/themes/dark/oasis_desert_dark.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Desert Dark",
+  "background": "#262626",
+  "foreground": "#F5F5DC",
+  "selectionBackground": "#433F38",
+  "cursorColor": "#F0E68C",
+  "black": "#262626",
+  "red": "#FF7979",
+  "green": "#7FCF78",
+  "yellow": "#F0E68C",
+  "blue": "#81C0FF",
+  "purple": "#C695FF",
+  "cyan": "#69C3AA",
+  "white": "#F5F5DC",
+  "brightBlack": "#77725F",
+  "brightRed": "#FFA0A0",
+  "brightGreen": "#A3E39A",
+  "brightYellow": "#F8B471",
+  "brightBlue": "#87CEEB",
+  "brightPurple": "#D2ADFF",
+  "brightCyan": "#8AD3BE",
+  "brightWhite": "#FFFFF0"
+}

--- a/extras/windows-terminal/themes/dark/oasis_dune_dark.json
+++ b/extras/windows-terminal/themes/dark/oasis_dune_dark.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Dune Dark",
+  "background": "#27211B",
+  "foreground": "#F5F5DC",
+  "selectionBackground": "#463E34",
+  "cursorColor": "#F0E68C",
+  "black": "#27211B",
+  "red": "#FF7979",
+  "green": "#7FCF78",
+  "yellow": "#F0E68C",
+  "blue": "#81C0FF",
+  "purple": "#C695FF",
+  "cyan": "#69C3AA",
+  "white": "#F5F5DC",
+  "brightBlack": "#826D5A",
+  "brightRed": "#FFA0A0",
+  "brightGreen": "#A3E39A",
+  "brightYellow": "#F8B471",
+  "brightBlue": "#87CEEB",
+  "brightPurple": "#D2ADFF",
+  "brightCyan": "#8AD3BE",
+  "brightWhite": "#FFFFF0"
+}

--- a/extras/windows-terminal/themes/dark/oasis_lagoon_dark.json
+++ b/extras/windows-terminal/themes/dark/oasis_lagoon_dark.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Lagoon Dark",
+  "background": "#101825",
+  "foreground": "#F5F5DC",
+  "selectionBackground": "#22385C",
+  "cursorColor": "#F0E68C",
+  "black": "#101825",
+  "red": "#FF7979",
+  "green": "#7FCF78",
+  "yellow": "#F0E68C",
+  "blue": "#81C0FF",
+  "purple": "#C695FF",
+  "cyan": "#69C3AA",
+  "white": "#F5F5DC",
+  "brightBlack": "#3B6A87",
+  "brightRed": "#FFA0A0",
+  "brightGreen": "#A3E39A",
+  "brightYellow": "#F8B471",
+  "brightBlue": "#87CEEB",
+  "brightPurple": "#D2ADFF",
+  "brightCyan": "#8AD3BE",
+  "brightWhite": "#FFFFF0"
+}

--- a/extras/windows-terminal/themes/dark/oasis_luna_dark.json
+++ b/extras/windows-terminal/themes/dark/oasis_luna_dark.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Luna Dark",
+  "background": "#0D0D2B",
+  "foreground": "#F5F5DC",
+  "selectionBackground": "#433F38",
+  "cursorColor": "#F0E68C",
+  "black": "#0D0D2B",
+  "red": "#FF7979",
+  "green": "#7FCF78",
+  "yellow": "#F0E68C",
+  "blue": "#81C0FF",
+  "purple": "#C695FF",
+  "cyan": "#69C3AA",
+  "white": "#F5F5DC",
+  "brightBlack": "#8A82B3",
+  "brightRed": "#FFA0A0",
+  "brightGreen": "#A3E39A",
+  "brightYellow": "#F8B471",
+  "brightBlue": "#87CEEB",
+  "brightPurple": "#D2ADFF",
+  "brightCyan": "#8AD3BE",
+  "brightWhite": "#FFFFF0"
+}

--- a/extras/windows-terminal/themes/dark/oasis_midnight_dark.json
+++ b/extras/windows-terminal/themes/dark/oasis_midnight_dark.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Midnight Dark",
+  "background": "#0C0E13",
+  "foreground": "#F5F5DC",
+  "selectionBackground": "#1E2A38",
+  "cursorColor": "#F0E68C",
+  "black": "#0C0E13",
+  "red": "#FF7979",
+  "green": "#7FCF78",
+  "yellow": "#F0E68C",
+  "blue": "#81C0FF",
+  "purple": "#C695FF",
+  "cyan": "#69C3AA",
+  "white": "#F5F5DC",
+  "brightBlack": "#4E6578",
+  "brightRed": "#FFA0A0",
+  "brightGreen": "#A3E39A",
+  "brightYellow": "#F8B471",
+  "brightBlue": "#87CEEB",
+  "brightPurple": "#D2ADFF",
+  "brightCyan": "#8AD3BE",
+  "brightWhite": "#FFFFF0"
+}

--- a/extras/windows-terminal/themes/dark/oasis_mirage_dark.json
+++ b/extras/windows-terminal/themes/dark/oasis_mirage_dark.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Mirage Dark",
+  "background": "#111C22",
+  "foreground": "#F5F5DC",
+  "selectionBackground": "#21333B",
+  "cursorColor": "#F0E68C",
+  "black": "#111C22",
+  "red": "#FF7979",
+  "green": "#7FCF78",
+  "yellow": "#F0E68C",
+  "blue": "#81C0FF",
+  "purple": "#C695FF",
+  "cyan": "#69C3AA",
+  "white": "#F5F5DC",
+  "brightBlack": "#587270",
+  "brightRed": "#FFA0A0",
+  "brightGreen": "#A3E39A",
+  "brightYellow": "#F8B471",
+  "brightBlue": "#87CEEB",
+  "brightPurple": "#D2ADFF",
+  "brightCyan": "#8AD3BE",
+  "brightWhite": "#FFFFF0"
+}

--- a/extras/windows-terminal/themes/dark/oasis_moonlight_dark.json
+++ b/extras/windows-terminal/themes/dark/oasis_moonlight_dark.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Moonlight Dark",
+  "background": "#0C0E13",
+  "foreground": "#F5F5DC",
+  "selectionBackground": "#24364D",
+  "cursorColor": "#F0E68C",
+  "black": "#0C0E13",
+  "red": "#FF7979",
+  "green": "#7FCF78",
+  "yellow": "#F0E68C",
+  "blue": "#81C0FF",
+  "purple": "#C695FF",
+  "cyan": "#69C3AA",
+  "white": "#F5F5DC",
+  "brightBlack": "#4E6578",
+  "brightRed": "#FFA0A0",
+  "brightGreen": "#A3E39A",
+  "brightYellow": "#F8B471",
+  "brightBlue": "#87CEEB",
+  "brightPurple": "#D2ADFF",
+  "brightCyan": "#8AD3BE",
+  "brightWhite": "#FFFFF0"
+}

--- a/extras/windows-terminal/themes/dark/oasis_night_dark.json
+++ b/extras/windows-terminal/themes/dark/oasis_night_dark.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Night Dark",
+  "background": "#08111C",
+  "foreground": "#F5F5DC",
+  "selectionBackground": "#24364D",
+  "cursorColor": "#F0E68C",
+  "black": "#08111C",
+  "red": "#FF7979",
+  "green": "#7FCF78",
+  "yellow": "#F0E68C",
+  "blue": "#81C0FF",
+  "purple": "#C695FF",
+  "cyan": "#69C3AA",
+  "white": "#F5F5DC",
+  "brightBlack": "#536B83",
+  "brightRed": "#FFA0A0",
+  "brightGreen": "#A3E39A",
+  "brightYellow": "#F8B471",
+  "brightBlue": "#87CEEB",
+  "brightPurple": "#D2ADFF",
+  "brightCyan": "#8AD3BE",
+  "brightWhite": "#FFFFF0"
+}

--- a/extras/windows-terminal/themes/dark/oasis_rose_dark.json
+++ b/extras/windows-terminal/themes/dark/oasis_rose_dark.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Rose Dark",
+  "background": "#2C1724",
+  "foreground": "#F5F5DC",
+  "selectionBackground": "#4E3747",
+  "cursorColor": "#F0E68C",
+  "black": "#2C1724",
+  "red": "#FF7979",
+  "green": "#7FCF78",
+  "yellow": "#F0E68C",
+  "blue": "#81C0FF",
+  "purple": "#C695FF",
+  "cyan": "#69C3AA",
+  "white": "#F5F5DC",
+  "brightBlack": "#816175",
+  "brightRed": "#FFA0A0",
+  "brightGreen": "#A3E39A",
+  "brightYellow": "#F8B471",
+  "brightBlue": "#87CEEB",
+  "brightPurple": "#D2ADFF",
+  "brightCyan": "#8AD3BE",
+  "brightWhite": "#FFFFF0"
+}

--- a/extras/windows-terminal/themes/dark/oasis_scorpion_dark.json
+++ b/extras/windows-terminal/themes/dark/oasis_scorpion_dark.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Scorpion Dark",
+  "background": "#1A0500",
+  "foreground": "#F5F5DC",
+  "selectionBackground": "#5A3824",
+  "cursorColor": "#F0E68C",
+  "black": "#1A0500",
+  "red": "#FF7979",
+  "green": "#7FCF78",
+  "yellow": "#F0E68C",
+  "blue": "#81C0FF",
+  "purple": "#C695FF",
+  "cyan": "#69C3AA",
+  "white": "#F5F5DC",
+  "brightBlack": "#9A6F66",
+  "brightRed": "#FFA0A0",
+  "brightGreen": "#A3E39A",
+  "brightYellow": "#F8B471",
+  "brightBlue": "#87CEEB",
+  "brightPurple": "#D2ADFF",
+  "brightCyan": "#8AD3BE",
+  "brightWhite": "#FFFFF0"
+}

--- a/extras/windows-terminal/themes/dark/oasis_sol_dark.json
+++ b/extras/windows-terminal/themes/dark/oasis_sol_dark.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Sol Dark",
+  "background": "#271311",
+  "foreground": "#F5F5DC",
+  "selectionBackground": "#432823",
+  "cursorColor": "#F0E68C",
+  "black": "#271311",
+  "red": "#FF7979",
+  "green": "#7FCF78",
+  "yellow": "#F0E68C",
+  "blue": "#81C0FF",
+  "purple": "#C695FF",
+  "cyan": "#69C3AA",
+  "white": "#F5F5DC",
+  "brightBlack": "#83615B",
+  "brightRed": "#FFA0A0",
+  "brightGreen": "#A3E39A",
+  "brightYellow": "#F8B471",
+  "brightBlue": "#87CEEB",
+  "brightPurple": "#D2ADFF",
+  "brightCyan": "#8AD3BE",
+  "brightWhite": "#FFFFF0"
+}

--- a/extras/windows-terminal/themes/dark/oasis_starlight_dark.json
+++ b/extras/windows-terminal/themes/dark/oasis_starlight_dark.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Starlight Dark",
+  "background": "#000000",
+  "foreground": "#F5F5DC",
+  "selectionBackground": "#4D4528",
+  "cursorColor": "#F0E68C",
+  "black": "#000000",
+  "red": "#FF7979",
+  "green": "#7FCF78",
+  "yellow": "#F0E68C",
+  "blue": "#81C0FF",
+  "purple": "#C695FF",
+  "cyan": "#69C3AA",
+  "white": "#F5F5DC",
+  "brightBlack": "#4F5B6B",
+  "brightRed": "#FFA0A0",
+  "brightGreen": "#A3E39A",
+  "brightYellow": "#F8B471",
+  "brightBlue": "#87CEEB",
+  "brightPurple": "#D2ADFF",
+  "brightCyan": "#8AD3BE",
+  "brightWhite": "#FFFFF0"
+}

--- a/extras/windows-terminal/themes/dark/oasis_twilight_dark.json
+++ b/extras/windows-terminal/themes/dark/oasis_twilight_dark.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Twilight Dark",
+  "background": "#1B1320",
+  "foreground": "#F5F5DC",
+  "selectionBackground": "#362343",
+  "cursorColor": "#F0E68C",
+  "black": "#1B1320",
+  "red": "#FF7979",
+  "green": "#7FCF78",
+  "yellow": "#F0E68C",
+  "blue": "#81C0FF",
+  "purple": "#C695FF",
+  "cyan": "#69C3AA",
+  "white": "#F5F5DC",
+  "brightBlack": "#71609A",
+  "brightRed": "#FFA0A0",
+  "brightGreen": "#A3E39A",
+  "brightYellow": "#F8B471",
+  "brightBlue": "#87CEEB",
+  "brightPurple": "#D2ADFF",
+  "brightCyan": "#8AD3BE",
+  "brightWhite": "#FFFFF0"
+}

--- a/extras/windows-terminal/themes/light/1/oasis_abyss_light_1.json
+++ b/extras/windows-terminal/themes/light/1/oasis_abyss_light_1.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Abyss Light 1",
+  "background": "#e7e7e7",
+  "foreground": "#181811",
+  "selectionBackground": "#c8c8c8",
+  "cursorColor": "#6e642c",
+  "black": "#414141",
+  "red": "#b01212",
+  "green": "#376133",
+  "yellow": "#5f5920",
+  "blue": "#14589e",
+  "purple": "#7422d5",
+  "cyan": "#365f54",
+  "white": "#43431f",
+  "brightBlack": "#494038",
+  "brightRed": "#b01212",
+  "brightGreen": "#34622e",
+  "brightYellow": "#814a13",
+  "brightBlue": "#225e77",
+  "brightPurple": "#7323d5",
+  "brightCyan": "#346054",
+  "brightWhite": "#44440e"
+}

--- a/extras/windows-terminal/themes/light/1/oasis_cactus_light_1.json
+++ b/extras/windows-terminal/themes/light/1/oasis_cactus_light_1.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Cactus Light 1",
+  "background": "#f1f9f4",
+  "foreground": "#1c1c13",
+  "selectionBackground": "#c6e7d2",
+  "cursorColor": "#467949",
+  "black": "#4b4b4b",
+  "red": "#c11313",
+  "green": "#3d6c39",
+  "yellow": "#696223",
+  "blue": "#1661ae",
+  "purple": "#7f30de",
+  "cyan": "#3c695d",
+  "white": "#4d4d24",
+  "brightBlack": "#534940",
+  "brightRed": "#c11313",
+  "brightGreen": "#396c32",
+  "brightYellow": "#8f5215",
+  "brightBlue": "#266883",
+  "brightPurple": "#7f31de",
+  "brightCyan": "#396a5c",
+  "brightWhite": "#4d4d10"
+}

--- a/extras/windows-terminal/themes/light/1/oasis_canyon_light_1.json
+++ b/extras/windows-terminal/themes/light/1/oasis_canyon_light_1.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Canyon Light 1",
+  "background": "#f4e3d5",
+  "foreground": "#181811",
+  "selectionBackground": "#e7c3a5",
+  "cursorColor": "#ae3d1d",
+  "black": "#414141",
+  "red": "#ae1111",
+  "green": "#376033",
+  "yellow": "#5e581f",
+  "blue": "#13589d",
+  "purple": "#7322d3",
+  "cyan": "#355e53",
+  "white": "#43431f",
+  "brightBlack": "#493f38",
+  "brightRed": "#ae1111",
+  "brightGreen": "#33612d",
+  "brightYellow": "#804913",
+  "brightBlue": "#225d76",
+  "brightPurple": "#7222d4",
+  "brightCyan": "#335f53",
+  "brightWhite": "#43430e"
+}

--- a/extras/windows-terminal/themes/light/1/oasis_desert_light_1.json
+++ b/extras/windows-terminal/themes/light/1/oasis_desert_light_1.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Desert Light 1",
+  "background": "#f9f6e7",
+  "foreground": "#1b1b13",
+  "selectionBackground": "#ede4b6",
+  "cursorColor": "#7a6d1c",
+  "black": "#4a4a4a",
+  "red": "#c01313",
+  "green": "#3d6b38",
+  "yellow": "#686123",
+  "blue": "#1561ad",
+  "purple": "#7f2edd",
+  "cyan": "#3b685c",
+  "white": "#4c4c24",
+  "brightBlack": "#534840",
+  "brightRed": "#c01313",
+  "brightGreen": "#396b32",
+  "brightYellow": "#8e5115",
+  "brightBlue": "#256782",
+  "brightPurple": "#7e2fdd",
+  "brightCyan": "#39695c",
+  "brightWhite": "#4c4c10"
+}

--- a/extras/windows-terminal/themes/light/1/oasis_dune_light_1.json
+++ b/extras/windows-terminal/themes/light/1/oasis_dune_light_1.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Dune Light 1",
+  "background": "#fcf6ee",
+  "foreground": "#1c1c13",
+  "selectionBackground": "#f3daba",
+  "cursorColor": "#7a6e1d",
+  "black": "#4a4a4a",
+  "red": "#c11313",
+  "green": "#3d6b39",
+  "yellow": "#696223",
+  "blue": "#1661ae",
+  "purple": "#7f30de",
+  "cyan": "#3b695c",
+  "white": "#4c4c24",
+  "brightBlack": "#534940",
+  "brightRed": "#c11313",
+  "brightGreen": "#396c32",
+  "brightYellow": "#8e5215",
+  "brightBlue": "#266883",
+  "brightPurple": "#7e30dd",
+  "brightCyan": "#396a5c",
+  "brightWhite": "#4d4d10"
+}

--- a/extras/windows-terminal/themes/light/1/oasis_lagoon_light_1.json
+++ b/extras/windows-terminal/themes/light/1/oasis_lagoon_light_1.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Lagoon Light 1",
+  "background": "#f2f7fd",
+  "foreground": "#1b1b13",
+  "selectionBackground": "#bdd6f5",
+  "cursorColor": "#176bd1",
+  "black": "#4a4a4a",
+  "red": "#c01313",
+  "green": "#3d6b39",
+  "yellow": "#696223",
+  "blue": "#1561ae",
+  "purple": "#7f2fde",
+  "cyan": "#3b695c",
+  "white": "#4c4c24",
+  "brightBlack": "#534840",
+  "brightRed": "#c01313",
+  "brightGreen": "#396c32",
+  "brightYellow": "#8e5215",
+  "brightBlue": "#266783",
+  "brightPurple": "#7e30dd",
+  "brightCyan": "#39695c",
+  "brightWhite": "#4d4d10"
+}

--- a/extras/windows-terminal/themes/light/1/oasis_luna_light_1.json
+++ b/extras/windows-terminal/themes/light/1/oasis_luna_light_1.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Luna Light 1",
+  "background": "#f3f3fc",
+  "foreground": "#191911",
+  "selectionBackground": "#c2c2f0",
+  "cursorColor": "#766c2f",
+  "black": "#494949",
+  "red": "#be1313",
+  "green": "#3c6938",
+  "yellow": "#676022",
+  "blue": "#1560ab",
+  "purple": "#7d2cdd",
+  "cyan": "#3a675b",
+  "white": "#4b4b23",
+  "brightBlack": "#51473f",
+  "brightRed": "#be1313",
+  "brightGreen": "#386a31",
+  "brightYellow": "#8c5015",
+  "brightBlue": "#256681",
+  "brightPurple": "#7d2ddd",
+  "brightCyan": "#38685b",
+  "brightWhite": "#4b4b10"
+}

--- a/extras/windows-terminal/themes/light/1/oasis_midnight_light_1.json
+++ b/extras/windows-terminal/themes/light/1/oasis_midnight_light_1.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Midnight Light 1",
+  "background": "#eceff4",
+  "foreground": "#181811",
+  "selectionBackground": "#c5cede",
+  "cursorColor": "#73692e",
+  "black": "#464646",
+  "red": "#b81212",
+  "green": "#3a6636",
+  "yellow": "#645d21",
+  "blue": "#155da6",
+  "purple": "#7a26dc",
+  "cyan": "#396458",
+  "white": "#484822",
+  "brightBlack": "#4e443c",
+  "brightRed": "#b81212",
+  "brightGreen": "#366730",
+  "brightYellow": "#884e14",
+  "brightBlue": "#24637d",
+  "brightPurple": "#7927dc",
+  "brightCyan": "#366458",
+  "brightWhite": "#48480f"
+}

--- a/extras/windows-terminal/themes/light/1/oasis_mirage_light_1.json
+++ b/extras/windows-terminal/themes/light/1/oasis_mirage_light_1.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Mirage Light 1",
+  "background": "#effaf8",
+  "foreground": "#1c1c14",
+  "selectionBackground": "#c0ebe4",
+  "cursorColor": "#387968",
+  "black": "#4b4b4b",
+  "red": "#c21313",
+  "green": "#3d6c39",
+  "yellow": "#696323",
+  "blue": "#1662af",
+  "purple": "#8030de",
+  "cyan": "#3c6a5d",
+  "white": "#4d4d24",
+  "brightBlack": "#544941",
+  "brightRed": "#c21414",
+  "brightGreen": "#396d33",
+  "brightYellow": "#8f5215",
+  "brightBlue": "#266884",
+  "brightPurple": "#7f31de",
+  "brightCyan": "#396a5d",
+  "brightWhite": "#4d4d10"
+}

--- a/extras/windows-terminal/themes/light/1/oasis_moonlight_light_1.json
+++ b/extras/windows-terminal/themes/light/1/oasis_moonlight_light_1.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Moonlight Light 1",
+  "background": "#f3f2eb",
+  "foreground": "#181811",
+  "selectionBackground": "#dcd9c5",
+  "cursorColor": "#756b2f",
+  "black": "#484848",
+  "red": "#bc1313",
+  "green": "#3b6837",
+  "yellow": "#665f22",
+  "blue": "#155fa9",
+  "purple": "#7c2add",
+  "cyan": "#3a665a",
+  "white": "#494922",
+  "brightBlack": "#50463e",
+  "brightRed": "#bc1313",
+  "brightGreen": "#376931",
+  "brightYellow": "#8a4f15",
+  "brightBlue": "#24647f",
+  "brightPurple": "#7b2bdd",
+  "brightCyan": "#37665a",
+  "brightWhite": "#4a4a10"
+}

--- a/extras/windows-terminal/themes/light/1/oasis_night_light_1.json
+++ b/extras/windows-terminal/themes/light/1/oasis_night_light_1.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Night Light 1",
+  "background": "#f3f5f7",
+  "foreground": "#1a1a12",
+  "selectionBackground": "#ced6de",
+  "cursorColor": "#776d2f",
+  "black": "#494949",
+  "red": "#bf1313",
+  "green": "#3c6a38",
+  "yellow": "#686123",
+  "blue": "#1560ac",
+  "purple": "#7e2ddd",
+  "cyan": "#3b685b",
+  "white": "#4b4b23",
+  "brightBlack": "#52473f",
+  "brightRed": "#bf1313",
+  "brightGreen": "#386b32",
+  "brightYellow": "#8d5115",
+  "brightBlue": "#256681",
+  "brightPurple": "#7d2edd",
+  "brightCyan": "#38685b",
+  "brightWhite": "#4c4c10"
+}

--- a/extras/windows-terminal/themes/light/1/oasis_rose_light_1.json
+++ b/extras/windows-terminal/themes/light/1/oasis_rose_light_1.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Rose Light 1",
+  "background": "#faeef5",
+  "foreground": "#181811",
+  "selectionBackground": "#ecbfd9",
+  "cursorColor": "#b3406e",
+  "black": "#474747",
+  "red": "#bb1313",
+  "green": "#3b6837",
+  "yellow": "#655f22",
+  "blue": "#155ea9",
+  "purple": "#7b29dd",
+  "cyan": "#39665a",
+  "white": "#494922",
+  "brightBlack": "#50453d",
+  "brightRed": "#bb1313",
+  "brightGreen": "#376831",
+  "brightYellow": "#8a4f14",
+  "brightBlue": "#24647f",
+  "brightPurple": "#7b2adc",
+  "brightCyan": "#376659",
+  "brightWhite": "#4a4a10"
+}

--- a/extras/windows-terminal/themes/light/1/oasis_scorpion_light_1.json
+++ b/extras/windows-terminal/themes/light/1/oasis_scorpion_light_1.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Scorpion Light 1",
+  "background": "#f9e4dd",
+  "foreground": "#181811",
+  "selectionBackground": "#f0bba9",
+  "cursorColor": "#6f652c",
+  "black": "#424242",
+  "red": "#b11212",
+  "green": "#386234",
+  "yellow": "#605a20",
+  "blue": "#14599f",
+  "purple": "#7522d6",
+  "cyan": "#366055",
+  "white": "#444420",
+  "brightBlack": "#4a4039",
+  "brightRed": "#b11212",
+  "brightGreen": "#34632e",
+  "brightYellow": "#824b13",
+  "brightBlue": "#225f78",
+  "brightPurple": "#7423d7",
+  "brightCyan": "#346054",
+  "brightWhite": "#44440e"
+}

--- a/extras/windows-terminal/themes/light/1/oasis_sol_light_1.json
+++ b/extras/windows-terminal/themes/light/1/oasis_sol_light_1.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Sol Light 1",
+  "background": "#f8dddd",
+  "foreground": "#181811",
+  "selectionBackground": "#eeaaaa",
+  "cursorColor": "#b9292c",
+  "black": "#3f3f3f",
+  "red": "#ab1111",
+  "green": "#365f32",
+  "yellow": "#5c561f",
+  "blue": "#13569a",
+  "purple": "#7121cf",
+  "cyan": "#345d52",
+  "white": "#41411e",
+  "brightBlack": "#473d36",
+  "brightRed": "#ab1111",
+  "brightGreen": "#325f2c",
+  "brightYellow": "#7e4813",
+  "brightBlue": "#215b74",
+  "brightPurple": "#7022d0",
+  "brightCyan": "#325d51",
+  "brightWhite": "#41410e"
+}

--- a/extras/windows-terminal/themes/light/1/oasis_starlight_light_1.json
+++ b/extras/windows-terminal/themes/light/1/oasis_starlight_light_1.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Starlight Light 1",
+  "background": "#faf9f5",
+  "foreground": "#1e1e14",
+  "selectionBackground": "#e6e1cc",
+  "cursorColor": "#796f31",
+  "black": "#4c4c4c",
+  "red": "#c31414",
+  "green": "#3e6d39",
+  "yellow": "#6a6323",
+  "blue": "#1663b1",
+  "purple": "#8132de",
+  "cyan": "#3c6a5e",
+  "white": "#4e4e24",
+  "brightBlack": "#554a41",
+  "brightRed": "#c31414",
+  "brightGreen": "#3a6e33",
+  "brightYellow": "#905315",
+  "brightBlue": "#266985",
+  "brightPurple": "#8033de",
+  "brightCyan": "#3a6b5e",
+  "brightWhite": "#4e4e11"
+}

--- a/extras/windows-terminal/themes/light/1/oasis_twilight_light_1.json
+++ b/extras/windows-terminal/themes/light/1/oasis_twilight_light_1.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Twilight Light 1",
+  "background": "#f8f4fb",
+  "foreground": "#1b1b13",
+  "selectionBackground": "#dbc7eb",
+  "cursorColor": "#be4320",
+  "black": "#4a4a4a",
+  "red": "#c01313",
+  "green": "#3c6a38",
+  "yellow": "#686123",
+  "blue": "#1561ad",
+  "purple": "#7e2edd",
+  "cyan": "#3b685c",
+  "white": "#4c4c23",
+  "brightBlack": "#524840",
+  "brightRed": "#c01313",
+  "brightGreen": "#386b32",
+  "brightYellow": "#8d5115",
+  "brightBlue": "#256782",
+  "brightPurple": "#7e2fdd",
+  "brightCyan": "#39695c",
+  "brightWhite": "#4c4c10"
+}

--- a/extras/windows-terminal/themes/light/2/oasis_abyss_light_2.json
+++ b/extras/windows-terminal/themes/light/2/oasis_abyss_light_2.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Abyss Light 2",
+  "background": "#e0e0e0",
+  "foreground": "#181811",
+  "selectionBackground": "#c1c1c1",
+  "cursorColor": "#69602a",
+  "black": "#3d3d3d",
+  "red": "#a81111",
+  "green": "#345c31",
+  "yellow": "#5b551e",
+  "blue": "#135497",
+  "purple": "#6f21ca",
+  "cyan": "#335b50",
+  "white": "#3f3f1d",
+  "brightBlack": "#453b35",
+  "brightRed": "#a81111",
+  "brightGreen": "#315d2b",
+  "brightYellow": "#7b4712",
+  "brightBlue": "#205971",
+  "brightPurple": "#6e21cb",
+  "brightCyan": "#315b4f",
+  "brightWhite": "#3f3f0d"
+}

--- a/extras/windows-terminal/themes/light/2/oasis_cactus_light_2.json
+++ b/extras/windows-terminal/themes/light/2/oasis_cactus_light_2.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Cactus Light 2",
+  "background": "#e7f4eb",
+  "foreground": "#181811",
+  "selectionBackground": "#bde1c8",
+  "cursorColor": "#447447",
+  "black": "#474747",
+  "red": "#ba1313",
+  "green": "#3b6737",
+  "yellow": "#655e22",
+  "blue": "#155ea8",
+  "purple": "#7b29dc",
+  "cyan": "#396559",
+  "white": "#494922",
+  "brightBlack": "#50453e",
+  "brightRed": "#ba1313",
+  "brightGreen": "#376830",
+  "brightYellow": "#8a4f14",
+  "brightBlue": "#24647e",
+  "brightPurple": "#7a2adc",
+  "brightCyan": "#376658",
+  "brightWhite": "#4a4a0f"
+}

--- a/extras/windows-terminal/themes/light/2/oasis_canyon_light_2.json
+++ b/extras/windows-terminal/themes/light/2/oasis_canyon_light_2.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Canyon Light 2",
+  "background": "#f1dbc9",
+  "foreground": "#181811",
+  "selectionBackground": "#e4bb98",
+  "cursorColor": "#a73b1d",
+  "black": "#3d3d3d",
+  "red": "#a61111",
+  "green": "#345c31",
+  "yellow": "#5a541e",
+  "blue": "#125395",
+  "purple": "#6e21c8",
+  "cyan": "#335a4f",
+  "white": "#3e3e1d",
+  "brightBlack": "#443b35",
+  "brightRed": "#a61111",
+  "brightGreen": "#315c2b",
+  "brightYellow": "#7a4612",
+  "brightBlue": "#205970",
+  "brightPurple": "#6d21c9",
+  "brightCyan": "#315a4e",
+  "brightWhite": "#3e3e0d"
+}

--- a/extras/windows-terminal/themes/light/2/oasis_desert_light_2.json
+++ b/extras/windows-terminal/themes/light/2/oasis_desert_light_2.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Desert Light 2",
+  "background": "#f6f2db",
+  "foreground": "#181811",
+  "selectionBackground": "#eae0aa",
+  "cursorColor": "#776b1d",
+  "black": "#474747",
+  "red": "#bb1313",
+  "green": "#3b6837",
+  "yellow": "#655f22",
+  "blue": "#155ea9",
+  "purple": "#7c2adc",
+  "cyan": "#396659",
+  "white": "#494922",
+  "brightBlack": "#50453e",
+  "brightRed": "#bb1313",
+  "brightGreen": "#376930",
+  "brightYellow": "#8a4f14",
+  "brightBlue": "#24647e",
+  "brightPurple": "#7b2bdc",
+  "brightCyan": "#376658",
+  "brightWhite": "#4a4a10"
+}

--- a/extras/windows-terminal/themes/light/2/oasis_dune_light_2.json
+++ b/extras/windows-terminal/themes/light/2/oasis_dune_light_2.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Dune Light 2",
+  "background": "#f9f0e1",
+  "foreground": "#181811",
+  "selectionBackground": "#efd7ae",
+  "cursorColor": "#766a1d",
+  "black": "#474747",
+  "red": "#ba1313",
+  "green": "#3b6837",
+  "yellow": "#655f22",
+  "blue": "#155ea8",
+  "purple": "#7c29dc",
+  "cyan": "#396659",
+  "white": "#494922",
+  "brightBlack": "#50453e",
+  "brightRed": "#bb1313",
+  "brightGreen": "#376830",
+  "brightYellow": "#8a4f14",
+  "brightBlue": "#24647e",
+  "brightPurple": "#7b2bdc",
+  "brightCyan": "#376658",
+  "brightWhite": "#4a4a0f"
+}

--- a/extras/windows-terminal/themes/light/2/oasis_lagoon_light_2.json
+++ b/extras/windows-terminal/themes/light/2/oasis_lagoon_light_2.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Lagoon Light 2",
+  "background": "#e9f2fc",
+  "foreground": "#181811",
+  "selectionBackground": "#b3d2f5",
+  "cursorColor": "#1668cc",
+  "black": "#474747",
+  "red": "#ba1313",
+  "green": "#3b6837",
+  "yellow": "#655f22",
+  "blue": "#155ea8",
+  "purple": "#7c29dc",
+  "cyan": "#396559",
+  "white": "#494922",
+  "brightBlack": "#50453e",
+  "brightRed": "#ba1313",
+  "brightGreen": "#376830",
+  "brightYellow": "#8a4f14",
+  "brightBlue": "#24647e",
+  "brightPurple": "#7a2adc",
+  "brightCyan": "#376658",
+  "brightWhite": "#4a4a0f"
+}

--- a/extras/windows-terminal/themes/light/2/oasis_luna_light_2.json
+++ b/extras/windows-terminal/themes/light/2/oasis_luna_light_2.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Luna Light 2",
+  "background": "#eeecfb",
+  "foreground": "#181811",
+  "selectionBackground": "#c1b9f0",
+  "cursorColor": "#72692e",
+  "black": "#454545",
+  "red": "#b71212",
+  "green": "#3a6536",
+  "yellow": "#635c21",
+  "blue": "#145ca5",
+  "purple": "#7925db",
+  "cyan": "#386357",
+  "white": "#474721",
+  "brightBlack": "#4e433c",
+  "brightRed": "#b71212",
+  "brightGreen": "#36662f",
+  "brightYellow": "#874d14",
+  "brightBlue": "#23627b",
+  "brightPurple": "#7826db",
+  "brightCyan": "#366456",
+  "brightWhite": "#47470f"
+}

--- a/extras/windows-terminal/themes/light/2/oasis_midnight_light_2.json
+++ b/extras/windows-terminal/themes/light/2/oasis_midnight_light_2.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Midnight Light 2",
+  "background": "#e3e6ee",
+  "foreground": "#181811",
+  "selectionBackground": "#bdc4d7",
+  "cursorColor": "#6d642c",
+  "black": "#414141",
+  "red": "#ae1212",
+  "green": "#376033",
+  "yellow": "#5f5820",
+  "blue": "#13589d",
+  "purple": "#7323d2",
+  "cyan": "#365f53",
+  "white": "#43431f",
+  "brightBlack": "#493f39",
+  "brightRed": "#ae1212",
+  "brightGreen": "#33612d",
+  "brightYellow": "#804913",
+  "brightBlue": "#225d76",
+  "brightPurple": "#7223d3",
+  "brightCyan": "#335f52",
+  "brightWhite": "#43430e"
+}

--- a/extras/windows-terminal/themes/light/2/oasis_mirage_light_2.json
+++ b/extras/windows-terminal/themes/light/2/oasis_mirage_light_2.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Mirage Light 2",
+  "background": "#e3f6f4",
+  "foreground": "#181811",
+  "selectionBackground": "#b5e7e2",
+  "cursorColor": "#377564",
+  "black": "#484848",
+  "red": "#bc1313",
+  "green": "#3b6837",
+  "yellow": "#665f22",
+  "blue": "#155fa9",
+  "purple": "#7c2bdc",
+  "cyan": "#3a665a",
+  "white": "#4a4a22",
+  "brightBlack": "#50463e",
+  "brightRed": "#bc1313",
+  "brightGreen": "#386931",
+  "brightYellow": "#8a4f14",
+  "brightBlue": "#24657f",
+  "brightPurple": "#7b2cdc",
+  "brightCyan": "#386759",
+  "brightWhite": "#4a4a10"
+}

--- a/extras/windows-terminal/themes/light/2/oasis_moonlight_light_2.json
+++ b/extras/windows-terminal/themes/light/2/oasis_moonlight_light_2.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Moonlight Light 2",
+  "background": "#eeebe2",
+  "foreground": "#181811",
+  "selectionBackground": "#d7d0bb",
+  "cursorColor": "#70672d",
+  "black": "#444444",
+  "red": "#b41212",
+  "green": "#396435",
+  "yellow": "#615b21",
+  "blue": "#145ba2",
+  "purple": "#7724d9",
+  "cyan": "#376256",
+  "white": "#464621",
+  "brightBlack": "#4c423b",
+  "brightRed": "#b41212",
+  "brightGreen": "#35652f",
+  "brightYellow": "#854c13",
+  "brightBlue": "#23607a",
+  "brightPurple": "#7624da",
+  "brightCyan": "#356255",
+  "brightWhite": "#46460f"
+}

--- a/extras/windows-terminal/themes/light/2/oasis_night_light_2.json
+++ b/extras/windows-terminal/themes/light/2/oasis_night_light_2.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Night Light 2",
+  "background": "#e4edf7",
+  "foreground": "#181811",
+  "selectionBackground": "#b4cfe9",
+  "cursorColor": "#71672d",
+  "black": "#444444",
+  "red": "#b51212",
+  "green": "#396435",
+  "yellow": "#625c21",
+  "blue": "#145ba3",
+  "purple": "#7824da",
+  "cyan": "#386256",
+  "white": "#464621",
+  "brightBlack": "#4d423c",
+  "brightRed": "#b51212",
+  "brightGreen": "#35652f",
+  "brightYellow": "#854d14",
+  "brightBlue": "#23617a",
+  "brightPurple": "#7725db",
+  "brightCyan": "#356355",
+  "brightWhite": "#47470f"
+}

--- a/extras/windows-terminal/themes/light/2/oasis_rose_light_2.json
+++ b/extras/windows-terminal/themes/light/2/oasis_rose_light_2.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Rose Light 2",
+  "background": "#f6e2ef",
+  "foreground": "#181811",
+  "selectionBackground": "#e8b3d5",
+  "cursorColor": "#aa3c68",
+  "black": "#424242",
+  "red": "#b01212",
+  "green": "#376134",
+  "yellow": "#5f5920",
+  "blue": "#13599f",
+  "purple": "#7423d4",
+  "cyan": "#365f54",
+  "white": "#444420",
+  "brightBlack": "#4a4039",
+  "brightRed": "#b01212",
+  "brightGreen": "#34622e",
+  "brightYellow": "#824a13",
+  "brightBlue": "#225e77",
+  "brightPurple": "#7323d5",
+  "brightCyan": "#346053",
+  "brightWhite": "#44440e"
+}

--- a/extras/windows-terminal/themes/light/2/oasis_scorpion_light_2.json
+++ b/extras/windows-terminal/themes/light/2/oasis_scorpion_light_2.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Scorpion Light 2",
+  "background": "#f6d9d0",
+  "foreground": "#181811",
+  "selectionBackground": "#ecaf9d",
+  "cursorColor": "#68602a",
+  "black": "#3d3d3d",
+  "red": "#a61111",
+  "green": "#345c31",
+  "yellow": "#5a541e",
+  "blue": "#125496",
+  "purple": "#6e21c8",
+  "cyan": "#335a4f",
+  "white": "#3e3e1d",
+  "brightBlack": "#443b35",
+  "brightRed": "#a61111",
+  "brightGreen": "#315d2b",
+  "brightYellow": "#7a4612",
+  "brightBlue": "#205970",
+  "brightPurple": "#6d21c9",
+  "brightCyan": "#315a4e",
+  "brightWhite": "#3f3f0d"
+}

--- a/extras/windows-terminal/themes/light/2/oasis_sol_light_2.json
+++ b/extras/windows-terminal/themes/light/2/oasis_sol_light_2.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Sol Light 2",
+  "background": "#f5d1d1",
+  "foreground": "#181811",
+  "selectionBackground": "#ea9f9f",
+  "cursorColor": "#ae262a",
+  "black": "#393939",
+  "red": "#a01010",
+  "green": "#32582f",
+  "yellow": "#56501d",
+  "blue": "#12508f",
+  "purple": "#6a20c0",
+  "cyan": "#31564c",
+  "white": "#3b3b1b",
+  "brightBlack": "#403832",
+  "brightRed": "#a01010",
+  "brightGreen": "#2f5929",
+  "brightYellow": "#754311",
+  "brightBlue": "#1f556b",
+  "brightPurple": "#6820c1",
+  "brightCyan": "#2f574b",
+  "brightWhite": "#3b3b0c"
+}

--- a/extras/windows-terminal/themes/light/2/oasis_starlight_light_2.json
+++ b/extras/windows-terminal/themes/light/2/oasis_starlight_light_2.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Starlight Light 2",
+  "background": "#faf8f4",
+  "foreground": "#1d1d14",
+  "selectionBackground": "#e7ddca",
+  "cursorColor": "#796f31",
+  "black": "#4b4b4b",
+  "red": "#c21414",
+  "green": "#3d6c3a",
+  "yellow": "#6a6323",
+  "blue": "#1662b0",
+  "purple": "#8031dd",
+  "cyan": "#3c6a5d",
+  "white": "#4d4d24",
+  "brightBlack": "#544942",
+  "brightRed": "#c21414",
+  "brightGreen": "#3a6d33",
+  "brightYellow": "#905215",
+  "brightBlue": "#266984",
+  "brightPurple": "#7f32dd",
+  "brightCyan": "#3a6a5c",
+  "brightWhite": "#4e4e10"
+}

--- a/extras/windows-terminal/themes/light/2/oasis_twilight_light_2.json
+++ b/extras/windows-terminal/themes/light/2/oasis_twilight_light_2.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Twilight Light 2",
+  "background": "#f1eaf8",
+  "foreground": "#181811",
+  "selectionBackground": "#d2bce9",
+  "cursorColor": "#b5401f",
+  "black": "#454545",
+  "red": "#b61212",
+  "green": "#396536",
+  "yellow": "#625c21",
+  "blue": "#145ca4",
+  "purple": "#7824db",
+  "cyan": "#386357",
+  "white": "#474721",
+  "brightBlack": "#4d433c",
+  "brightRed": "#b61212",
+  "brightGreen": "#36662f",
+  "brightYellow": "#864d14",
+  "brightBlue": "#23617b",
+  "brightPurple": "#7725db",
+  "brightCyan": "#366356",
+  "brightWhite": "#47470f"
+}

--- a/extras/windows-terminal/themes/light/3/oasis_abyss_light_3.json
+++ b/extras/windows-terminal/themes/light/3/oasis_abyss_light_3.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Abyss Light 3",
+  "background": "#d8d8d8",
+  "foreground": "#181811",
+  "selectionBackground": "#b9b9b9",
+  "cursorColor": "#635c28",
+  "black": "#383838",
+  "red": "#9e1010",
+  "green": "#31572e",
+  "yellow": "#554f1c",
+  "blue": "#11508d",
+  "purple": "#691fbe",
+  "cyan": "#31554c",
+  "white": "#3a3a1b",
+  "brightBlack": "#3f3731",
+  "brightRed": "#9e1010",
+  "brightGreen": "#2f5829",
+  "brightYellow": "#744211",
+  "brightBlue": "#1e546a",
+  "brightPurple": "#671fc0",
+  "brightCyan": "#2f564a",
+  "brightWhite": "#3a3a0c"
+}

--- a/extras/windows-terminal/themes/light/3/oasis_cactus_light_3.json
+++ b/extras/windows-terminal/themes/light/3/oasis_cactus_light_3.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Cactus Light 3",
+  "background": "#dcefe3",
+  "foreground": "#181811",
+  "selectionBackground": "#b2dcc1",
+  "cursorColor": "#417144",
+  "black": "#434343",
+  "red": "#b31212",
+  "green": "#386334",
+  "yellow": "#615b20",
+  "blue": "#145ba1",
+  "purple": "#7723d8",
+  "cyan": "#376156",
+  "white": "#454520",
+  "brightBlack": "#4b423a",
+  "brightRed": "#b31212",
+  "brightGreen": "#35642e",
+  "brightYellow": "#844c14",
+  "brightBlue": "#226078",
+  "brightPurple": "#7524d9",
+  "brightCyan": "#366255",
+  "brightWhite": "#46460f"
+}

--- a/extras/windows-terminal/themes/light/3/oasis_canyon_light_3.json
+++ b/extras/windows-terminal/themes/light/3/oasis_canyon_light_3.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Canyon Light 3",
+  "background": "#eed3bd",
+  "foreground": "#181811",
+  "selectionBackground": "#e1b38c",
+  "cursorColor": "#9f381a",
+  "black": "#383838",
+  "red": "#9e1010",
+  "green": "#31572e",
+  "yellow": "#554f1c",
+  "blue": "#114f8d",
+  "purple": "#681fbe",
+  "cyan": "#31554b",
+  "white": "#3a3a1b",
+  "brightBlack": "#3e3731",
+  "brightRed": "#9e1010",
+  "brightGreen": "#2f5828",
+  "brightYellow": "#744211",
+  "brightBlue": "#1e5469",
+  "brightPurple": "#671fbf",
+  "brightCyan": "#2f564a",
+  "brightWhite": "#3a3a0c"
+}

--- a/extras/windows-terminal/themes/light/3/oasis_desert_light_3.json
+++ b/extras/windows-terminal/themes/light/3/oasis_desert_light_3.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Desert Light 3",
+  "background": "#f3edcf",
+  "foreground": "#181811",
+  "selectionBackground": "#e7db9e",
+  "cursorColor": "#74671c",
+  "black": "#444444",
+  "red": "#b61212",
+  "green": "#396535",
+  "yellow": "#635c21",
+  "blue": "#145ca2",
+  "purple": "#7824db",
+  "cyan": "#386257",
+  "white": "#464621",
+  "brightBlack": "#4c433b",
+  "brightRed": "#b61212",
+  "brightGreen": "#36652f",
+  "brightYellow": "#864d14",
+  "brightBlue": "#23617a",
+  "brightPurple": "#7725db",
+  "brightCyan": "#366356",
+  "brightWhite": "#47470f"
+}

--- a/extras/windows-terminal/themes/light/3/oasis_dune_light_3.json
+++ b/extras/windows-terminal/themes/light/3/oasis_dune_light_3.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Dune Light 3",
+  "background": "#f7e9d4",
+  "foreground": "#181811",
+  "selectionBackground": "#edcfa0",
+  "cursorColor": "#73661c",
+  "black": "#444444",
+  "red": "#b41212",
+  "green": "#386334",
+  "yellow": "#615b20",
+  "blue": "#145ba1",
+  "purple": "#7723d9",
+  "cyan": "#386156",
+  "white": "#454520",
+  "brightBlack": "#4b423b",
+  "brightRed": "#b41212",
+  "brightGreen": "#35642e",
+  "brightYellow": "#854c14",
+  "brightBlue": "#226079",
+  "brightPurple": "#7624da",
+  "brightCyan": "#366255",
+  "brightWhite": "#46460f"
+}

--- a/extras/windows-terminal/themes/light/3/oasis_lagoon_light_3.json
+++ b/extras/windows-terminal/themes/light/3/oasis_lagoon_light_3.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Lagoon Light 3",
+  "background": "#dceafa",
+  "foreground": "#181811",
+  "selectionBackground": "#a6caf2",
+  "cursorColor": "#1563c1",
+  "black": "#424242",
+  "red": "#b11212",
+  "green": "#386233",
+  "yellow": "#605920",
+  "blue": "#13599f",
+  "purple": "#7523d5",
+  "cyan": "#376055",
+  "white": "#444420",
+  "brightBlack": "#4a4139",
+  "brightRed": "#b11212",
+  "brightGreen": "#34632e",
+  "brightYellow": "#824b14",
+  "brightBlue": "#225f77",
+  "brightPurple": "#7423d7",
+  "brightCyan": "#356054",
+  "brightWhite": "#45450f"
+}

--- a/extras/windows-terminal/themes/light/3/oasis_luna_light_3.json
+++ b/extras/windows-terminal/themes/light/3/oasis_luna_light_3.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Luna Light 3",
+  "background": "#e2e0f8",
+  "foreground": "#181811",
+  "selectionBackground": "#b3aeed",
+  "cursorColor": "#6a622a",
+  "black": "#3e3e3e",
+  "red": "#aa1111",
+  "green": "#355e31",
+  "yellow": "#5c561f",
+  "blue": "#135698",
+  "purple": "#7121cd",
+  "cyan": "#355c52",
+  "white": "#40401e",
+  "brightBlack": "#463d36",
+  "brightRed": "#aa1111",
+  "brightGreen": "#325f2c",
+  "brightYellow": "#7d4813",
+  "brightBlue": "#205b72",
+  "brightPurple": "#6f22ce",
+  "brightCyan": "#335c50",
+  "brightWhite": "#41410e"
+}

--- a/extras/windows-terminal/themes/light/3/oasis_midnight_light_3.json
+++ b/extras/windows-terminal/themes/light/3/oasis_midnight_light_3.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Midnight Light 3",
+  "background": "#d9dee8",
+  "foreground": "#181811",
+  "selectionBackground": "#b3bdd1",
+  "cursorColor": "#675f29",
+  "black": "#3c3c3c",
+  "red": "#a51111",
+  "green": "#345b30",
+  "yellow": "#59531e",
+  "blue": "#125393",
+  "purple": "#6d20c7",
+  "cyan": "#33594f",
+  "white": "#3e3e1d",
+  "brightBlack": "#433a34",
+  "brightRed": "#a51111",
+  "brightGreen": "#315c2a",
+  "brightYellow": "#794512",
+  "brightBlue": "#1f586e",
+  "brightPurple": "#6c21c8",
+  "brightCyan": "#31594e",
+  "brightWhite": "#3e3e0d"
+}

--- a/extras/windows-terminal/themes/light/3/oasis_mirage_light_3.json
+++ b/extras/windows-terminal/themes/light/3/oasis_mirage_light_3.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Mirage Light 3",
+  "background": "#d8f2ef",
+  "foreground": "#181811",
+  "selectionBackground": "#aae3dc",
+  "cursorColor": "#367261",
+  "black": "#454545",
+  "red": "#b61212",
+  "green": "#396535",
+  "yellow": "#635c21",
+  "blue": "#145ca3",
+  "purple": "#7824db",
+  "cyan": "#386357",
+  "white": "#464621",
+  "brightBlack": "#4c433b",
+  "brightRed": "#b61212",
+  "brightGreen": "#36652f",
+  "brightYellow": "#864d14",
+  "brightBlue": "#23617a",
+  "brightPurple": "#7725db",
+  "brightCyan": "#366356",
+  "brightWhite": "#47470f"
+}

--- a/extras/windows-terminal/themes/light/3/oasis_moonlight_light_3.json
+++ b/extras/windows-terminal/themes/light/3/oasis_moonlight_light_3.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Moonlight Light 3",
+  "background": "#e8e5d8",
+  "foreground": "#181811",
+  "selectionBackground": "#d1cbb2",
+  "cursorColor": "#6b632b",
+  "black": "#404040",
+  "red": "#ad1111",
+  "green": "#366032",
+  "yellow": "#5e571f",
+  "blue": "#13579b",
+  "purple": "#7322d1",
+  "cyan": "#365e53",
+  "white": "#42421f",
+  "brightBlack": "#483f38",
+  "brightRed": "#ad1111",
+  "brightGreen": "#33602c",
+  "brightYellow": "#7f4913",
+  "brightBlue": "#215d74",
+  "brightPurple": "#7122d2",
+  "brightCyan": "#345e52",
+  "brightWhite": "#42420e"
+}

--- a/extras/windows-terminal/themes/light/3/oasis_night_light_3.json
+++ b/extras/windows-terminal/themes/light/3/oasis_night_light_3.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Night Light 3",
+  "background": "#d1e2f5",
+  "foreground": "#181811",
+  "selectionBackground": "#9ec2eb",
+  "cursorColor": "#68602a",
+  "black": "#3d3d3d",
+  "red": "#a81111",
+  "green": "#355d31",
+  "yellow": "#5b551e",
+  "blue": "#125496",
+  "purple": "#6f21ca",
+  "cyan": "#345b50",
+  "white": "#3f3f1e",
+  "brightBlack": "#443c35",
+  "brightRed": "#a81111",
+  "brightGreen": "#325d2b",
+  "brightYellow": "#7b4613",
+  "brightBlue": "#205a70",
+  "brightPurple": "#6e21cb",
+  "brightCyan": "#325b4f",
+  "brightWhite": "#3f3f0e"
+}

--- a/extras/windows-terminal/themes/light/3/oasis_rose_light_3.json
+++ b/extras/windows-terminal/themes/light/3/oasis_rose_light_3.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Rose Light 3",
+  "background": "#f3d6e8",
+  "foreground": "#181811",
+  "selectionBackground": "#e5a7cd",
+  "cursorColor": "#9f3a62",
+  "black": "#3c3c3c",
+  "red": "#a51111",
+  "green": "#345b30",
+  "yellow": "#59531e",
+  "blue": "#125393",
+  "purple": "#6d20c7",
+  "cyan": "#33594f",
+  "white": "#3e3e1d",
+  "brightBlack": "#433a34",
+  "brightRed": "#a51111",
+  "brightGreen": "#315c2a",
+  "brightYellow": "#794512",
+  "brightBlue": "#1f586f",
+  "brightPurple": "#6c21c8",
+  "brightCyan": "#31594e",
+  "brightWhite": "#3e3e0d"
+}

--- a/extras/windows-terminal/themes/light/3/oasis_scorpion_light_3.json
+++ b/extras/windows-terminal/themes/light/3/oasis_scorpion_light_3.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Scorpion Light 3",
+  "background": "#f4cfc3",
+  "foreground": "#181811",
+  "selectionBackground": "#eba68f",
+  "cursorColor": "#625b27",
+  "black": "#373737",
+  "red": "#9d1010",
+  "green": "#31562d",
+  "yellow": "#554f1c",
+  "blue": "#114f8b",
+  "purple": "#681fbd",
+  "cyan": "#30554b",
+  "white": "#39391b",
+  "brightBlack": "#3e3630",
+  "brightRed": "#9d1010",
+  "brightGreen": "#2e5728",
+  "brightYellow": "#734211",
+  "brightBlue": "#1e5469",
+  "brightPurple": "#661fbe",
+  "brightCyan": "#2e554a",
+  "brightWhite": "#39390c"
+}

--- a/extras/windows-terminal/themes/light/3/oasis_sol_light_3.json
+++ b/extras/windows-terminal/themes/light/3/oasis_sol_light_3.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Sol Light 3",
+  "background": "#f2c4c4",
+  "foreground": "#181811",
+  "selectionBackground": "#e79292",
+  "cursorColor": "#a22327",
+  "black": "#323232",
+  "red": "#930f0f",
+  "green": "#2e512a",
+  "yellow": "#4f4a1a",
+  "blue": "#104a83",
+  "purple": "#611db1",
+  "cyan": "#2d4f46",
+  "white": "#343418",
+  "brightBlack": "#38312c",
+  "brightRed": "#930f0f",
+  "brightGreen": "#2b5126",
+  "brightYellow": "#6b3e10",
+  "brightBlue": "#1c4e62",
+  "brightPurple": "#601db2",
+  "brightCyan": "#2b4f45",
+  "brightWhite": "#34340b"
+}

--- a/extras/windows-terminal/themes/light/3/oasis_starlight_light_3.json
+++ b/extras/windows-terminal/themes/light/3/oasis_starlight_light_3.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Starlight Light 3",
+  "background": "#f5f2ea",
+  "foreground": "#181811",
+  "selectionBackground": "#e1d8c1",
+  "cursorColor": "#746b2e",
+  "black": "#484848",
+  "red": "#bc1313",
+  "green": "#3b6837",
+  "yellow": "#665f22",
+  "blue": "#155fa8",
+  "purple": "#7d2adc",
+  "cyan": "#3a665a",
+  "white": "#4a4a23",
+  "brightBlack": "#50463e",
+  "brightRed": "#bc1313",
+  "brightGreen": "#386930",
+  "brightYellow": "#8b4f15",
+  "brightBlue": "#24657f",
+  "brightPurple": "#7b2bdc",
+  "brightCyan": "#386659",
+  "brightWhite": "#4a4a10"
+}

--- a/extras/windows-terminal/themes/light/3/oasis_twilight_light_3.json
+++ b/extras/windows-terminal/themes/light/3/oasis_twilight_light_3.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Twilight Light 3",
+  "background": "#eadff4",
+  "foreground": "#181811",
+  "selectionBackground": "#ccb1e4",
+  "cursorColor": "#ab3d1c",
+  "black": "#3f3f3f",
+  "red": "#ab1111",
+  "green": "#365f32",
+  "yellow": "#5d561f",
+  "blue": "#135699",
+  "purple": "#7121ce",
+  "cyan": "#355d52",
+  "white": "#41411e",
+  "brightBlack": "#463d37",
+  "brightRed": "#ab1111",
+  "brightGreen": "#335f2c",
+  "brightYellow": "#7e4813",
+  "brightBlue": "#215b73",
+  "brightPurple": "#7022d0",
+  "brightCyan": "#335d51",
+  "brightWhite": "#41410e"
+}

--- a/extras/windows-terminal/themes/light/4/oasis_abyss_light_4.json
+++ b/extras/windows-terminal/themes/light/4/oasis_abyss_light_4.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Abyss Light 4",
+  "background": "#d0d0d0",
+  "foreground": "#181811",
+  "selectionBackground": "#b1b1b1",
+  "cursorColor": "#5e5625",
+  "black": "#333333",
+  "red": "#950f0f",
+  "green": "#2e522b",
+  "yellow": "#504a1b",
+  "blue": "#104a84",
+  "purple": "#621db2",
+  "cyan": "#2d5046",
+  "white": "#343419",
+  "brightBlack": "#39322c",
+  "brightRed": "#950e0e",
+  "brightGreen": "#2b5226",
+  "brightYellow": "#6d3e10",
+  "brightBlue": "#1c4f63",
+  "brightPurple": "#611db4",
+  "brightCyan": "#2b5046",
+  "brightWhite": "#35350b"
+}

--- a/extras/windows-terminal/themes/light/4/oasis_cactus_light_4.json
+++ b/extras/windows-terminal/themes/light/4/oasis_cactus_light_4.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Cactus Light 4",
+  "background": "#d2eadb",
+  "foreground": "#181811",
+  "selectionBackground": "#a8d7ba",
+  "cursorColor": "#406c42",
+  "black": "#404040",
+  "red": "#ac1111",
+  "green": "#365f33",
+  "yellow": "#5d571f",
+  "blue": "#13579a",
+  "purple": "#7222cf",
+  "cyan": "#355d52",
+  "white": "#41411f",
+  "brightBlack": "#473e38",
+  "brightRed": "#ac1111",
+  "brightGreen": "#33602c",
+  "brightYellow": "#7f4813",
+  "brightBlue": "#215c74",
+  "brightPurple": "#7122d1",
+  "brightCyan": "#335e51",
+  "brightWhite": "#42420e"
+}

--- a/extras/windows-terminal/themes/light/4/oasis_canyon_light_4.json
+++ b/extras/windows-terminal/themes/light/4/oasis_canyon_light_4.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Canyon Light 4",
+  "background": "#ebcbb1",
+  "foreground": "#181811",
+  "selectionBackground": "#dfab80",
+  "cursorColor": "#97361a",
+  "black": "#333333",
+  "red": "#960f0f",
+  "green": "#2e522c",
+  "yellow": "#504b1b",
+  "blue": "#104b85",
+  "purple": "#631eb3",
+  "cyan": "#2d5146",
+  "white": "#353519",
+  "brightBlack": "#39322d",
+  "brightRed": "#960f0f",
+  "brightGreen": "#2c5326",
+  "brightYellow": "#6e3f10",
+  "brightBlue": "#1c4f64",
+  "brightPurple": "#621db5",
+  "brightCyan": "#2c5146",
+  "brightWhite": "#35350b"
+}

--- a/extras/windows-terminal/themes/light/4/oasis_desert_light_4.json
+++ b/extras/windows-terminal/themes/light/4/oasis_desert_light_4.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Desert Light 4",
+  "background": "#f0e8c3",
+  "foreground": "#181811",
+  "selectionBackground": "#e4d592",
+  "cursorColor": "#70651b",
+  "black": "#424242",
+  "red": "#b01212",
+  "green": "#376134",
+  "yellow": "#5f5920",
+  "blue": "#13599d",
+  "purple": "#7523d4",
+  "cyan": "#365f53",
+  "white": "#434320",
+  "brightBlack": "#494039",
+  "brightRed": "#b01111",
+  "brightGreen": "#34622d",
+  "brightYellow": "#824a13",
+  "brightBlue": "#225e77",
+  "brightPurple": "#7322d6",
+  "brightCyan": "#346053",
+  "brightWhite": "#44440e"
+}

--- a/extras/windows-terminal/themes/light/4/oasis_dune_light_4.json
+++ b/extras/windows-terminal/themes/light/4/oasis_dune_light_4.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Dune Light 4",
+  "background": "#f5e2c7",
+  "foreground": "#181811",
+  "selectionBackground": "#ecc793",
+  "cursorColor": "#6e631b",
+  "black": "#404040",
+  "red": "#ad1212",
+  "green": "#366033",
+  "yellow": "#5e571f",
+  "blue": "#13579a",
+  "purple": "#7222d0",
+  "cyan": "#355e52",
+  "white": "#42421f",
+  "brightBlack": "#473e38",
+  "brightRed": "#ad1111",
+  "brightGreen": "#33602c",
+  "brightYellow": "#7f4913",
+  "brightBlue": "#215c74",
+  "brightPurple": "#7122d2",
+  "brightCyan": "#335e52",
+  "brightWhite": "#42420e"
+}

--- a/extras/windows-terminal/themes/light/4/oasis_lagoon_light_4.json
+++ b/extras/windows-terminal/themes/light/4/oasis_lagoon_light_4.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Lagoon Light 4",
+  "background": "#cfe2f8",
+  "foreground": "#181811",
+  "selectionBackground": "#9ac2f0",
+  "cursorColor": "#145eb7",
+  "black": "#3d3d3d",
+  "red": "#a81111",
+  "green": "#345c31",
+  "yellow": "#5a541e",
+  "blue": "#125496",
+  "purple": "#6f21c9",
+  "cyan": "#335b4f",
+  "white": "#3f3f1e",
+  "brightBlack": "#443c35",
+  "brightRed": "#a71010",
+  "brightGreen": "#315d2b",
+  "brightYellow": "#7b4612",
+  "brightBlue": "#205970",
+  "brightPurple": "#6e21cb",
+  "brightCyan": "#315b4f",
+  "brightWhite": "#3f3f0d"
+}

--- a/extras/windows-terminal/themes/light/4/oasis_luna_light_4.json
+++ b/extras/windows-terminal/themes/light/4/oasis_luna_light_4.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Luna Light 4",
+  "background": "#d6d4f5",
+  "foreground": "#181811",
+  "selectionBackground": "#a7a2e9",
+  "cursorColor": "#635b27",
+  "black": "#373737",
+  "red": "#9d1010",
+  "green": "#31562e",
+  "yellow": "#554f1c",
+  "blue": "#114f8c",
+  "purple": "#681fbd",
+  "cyan": "#30554a",
+  "white": "#39391b",
+  "brightBlack": "#3e3630",
+  "brightRed": "#9d0f0f",
+  "brightGreen": "#2e5728",
+  "brightYellow": "#734211",
+  "brightBlue": "#1e5469",
+  "brightPurple": "#671fbf",
+  "brightCyan": "#2e554a",
+  "brightWhite": "#3a3a0c"
+}

--- a/extras/windows-terminal/themes/light/4/oasis_midnight_light_4.json
+++ b/extras/windows-terminal/themes/light/4/oasis_midnight_light_4.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Midnight Light 4",
+  "background": "#cfd6e2",
+  "foreground": "#181811",
+  "selectionBackground": "#a9b5cb",
+  "cursorColor": "#625a27",
+  "black": "#373737",
+  "red": "#9b1010",
+  "green": "#30552d",
+  "yellow": "#534e1c",
+  "blue": "#114e8a",
+  "purple": "#661fba",
+  "cyan": "#2f5449",
+  "white": "#38381a",
+  "brightBlack": "#3d3530",
+  "brightRed": "#9b0f0f",
+  "brightGreen": "#2d5628",
+  "brightYellow": "#724111",
+  "brightBlue": "#1d5368",
+  "brightPurple": "#661ebc",
+  "brightCyan": "#2d5449",
+  "brightWhite": "#38380c"
+}

--- a/extras/windows-terminal/themes/light/4/oasis_mirage_light_4.json
+++ b/extras/windows-terminal/themes/light/4/oasis_mirage_light_4.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Mirage Light 4",
+  "background": "#cdeeea",
+  "foreground": "#181811",
+  "selectionBackground": "#9fded7",
+  "cursorColor": "#356e5e",
+  "black": "#424242",
+  "red": "#b01212",
+  "green": "#376134",
+  "yellow": "#5f5920",
+  "blue": "#13599d",
+  "purple": "#7423d3",
+  "cyan": "#365f53",
+  "white": "#434320",
+  "brightBlack": "#494039",
+  "brightRed": "#b01111",
+  "brightGreen": "#34622d",
+  "brightYellow": "#814a13",
+  "brightBlue": "#215e76",
+  "brightPurple": "#7322d5",
+  "brightCyan": "#346053",
+  "brightWhite": "#44440e"
+}

--- a/extras/windows-terminal/themes/light/4/oasis_moonlight_light_4.json
+++ b/extras/windows-terminal/themes/light/4/oasis_moonlight_light_4.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Moonlight Light 4",
+  "background": "#e2dfce",
+  "foreground": "#181811",
+  "selectionBackground": "#cbc6a8",
+  "cursorColor": "#685f29",
+  "black": "#3c3c3c",
+  "red": "#a61111",
+  "green": "#345c31",
+  "yellow": "#5a541e",
+  "blue": "#125394",
+  "purple": "#6e21c7",
+  "cyan": "#335a4f",
+  "white": "#3e3e1d",
+  "brightBlack": "#433b35",
+  "brightRed": "#a61010",
+  "brightGreen": "#315c2a",
+  "brightYellow": "#7a4612",
+  "brightBlue": "#20596f",
+  "brightPurple": "#6d20c9",
+  "brightCyan": "#315a4e",
+  "brightWhite": "#3e3e0d"
+}

--- a/extras/windows-terminal/themes/light/4/oasis_night_light_4.json
+++ b/extras/windows-terminal/themes/light/4/oasis_night_light_4.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Night Light 4",
+  "background": "#c1daf6",
+  "foreground": "#181811",
+  "selectionBackground": "#8cbbee",
+  "cursorColor": "#635b27",
+  "black": "#383838",
+  "red": "#9d1010",
+  "green": "#31572e",
+  "yellow": "#554f1c",
+  "blue": "#114f8c",
+  "purple": "#681fbd",
+  "cyan": "#30554a",
+  "white": "#39391b",
+  "brightBlack": "#3e3631",
+  "brightRed": "#9d0f0f",
+  "brightGreen": "#2e5728",
+  "brightYellow": "#734211",
+  "brightBlue": "#1e5469",
+  "brightPurple": "#671fbf",
+  "brightCyan": "#2e554a",
+  "brightWhite": "#3a3a0c"
+}

--- a/extras/windows-terminal/themes/light/4/oasis_rose_light_4.json
+++ b/extras/windows-terminal/themes/light/4/oasis_rose_light_4.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Rose Light 4",
+  "background": "#f0cae1",
+  "foreground": "#181811",
+  "selectionBackground": "#e39ac6",
+  "cursorColor": "#96365c",
+  "black": "#363636",
+  "red": "#9a1010",
+  "green": "#30552d",
+  "yellow": "#534d1c",
+  "blue": "#114d89",
+  "purple": "#661fb9",
+  "cyan": "#2f5349",
+  "white": "#37371a",
+  "brightBlack": "#3c352f",
+  "brightRed": "#9a0f0f",
+  "brightGreen": "#2d5527",
+  "brightYellow": "#714111",
+  "brightBlue": "#1d5267",
+  "brightPurple": "#651ebb",
+  "brightCyan": "#2d5348",
+  "brightWhite": "#38380c"
+}

--- a/extras/windows-terminal/themes/light/4/oasis_scorpion_light_4.json
+++ b/extras/windows-terminal/themes/light/4/oasis_scorpion_light_4.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Scorpion Light 4",
+  "background": "#f2c5b6",
+  "foreground": "#181811",
+  "selectionBackground": "#e99c82",
+  "cursorColor": "#5d5525",
+  "black": "#323232",
+  "red": "#930f0f",
+  "green": "#2e512b",
+  "yellow": "#4f4a1a",
+  "blue": "#104a83",
+  "purple": "#611db0",
+  "cyan": "#2d4f45",
+  "white": "#333318",
+  "brightBlack": "#38312c",
+  "brightRed": "#930e0e",
+  "brightGreen": "#2b5125",
+  "brightYellow": "#6c3e10",
+  "brightBlue": "#1c4e62",
+  "brightPurple": "#601db2",
+  "brightCyan": "#2b4f45",
+  "brightWhite": "#34340b"
+}

--- a/extras/windows-terminal/themes/light/4/oasis_sol_light_4.json
+++ b/extras/windows-terminal/themes/light/4/oasis_sol_light_4.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Sol Light 4",
+  "background": "#efb7b7",
+  "foreground": "#181811",
+  "selectionBackground": "#e48585",
+  "cursorColor": "#962024",
+  "black": "#2b2b2b",
+  "red": "#870e0e",
+  "green": "#2a4a27",
+  "yellow": "#484318",
+  "blue": "#0f4377",
+  "purple": "#591ba1",
+  "cyan": "#29483f",
+  "white": "#2c2c15",
+  "brightBlack": "#302a25",
+  "brightRed": "#870d0d",
+  "brightGreen": "#274a22",
+  "brightYellow": "#62380f",
+  "brightBlue": "#19475a",
+  "brightPurple": "#581aa3",
+  "brightCyan": "#27483f",
+  "brightWhite": "#2c2c09"
+}

--- a/extras/windows-terminal/themes/light/4/oasis_starlight_light_4.json
+++ b/extras/windows-terminal/themes/light/4/oasis_starlight_light_4.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Starlight Light 4",
+  "background": "#f0ece0",
+  "foreground": "#181811",
+  "selectionBackground": "#dcd3b7",
+  "cursorColor": "#71682d",
+  "black": "#444444",
+  "red": "#b51212",
+  "green": "#396435",
+  "yellow": "#625c21",
+  "blue": "#145ba2",
+  "purple": "#7824da",
+  "cyan": "#376256",
+  "white": "#464621",
+  "brightBlack": "#4c423c",
+  "brightRed": "#b51212",
+  "brightGreen": "#35652f",
+  "brightYellow": "#864c14",
+  "brightBlue": "#23617a",
+  "brightPurple": "#7724dc",
+  "brightCyan": "#356356",
+  "brightWhite": "#47470f"
+}

--- a/extras/windows-terminal/themes/light/4/oasis_twilight_light_4.json
+++ b/extras/windows-terminal/themes/light/4/oasis_twilight_light_4.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Twilight Light 4",
+  "background": "#e3d4f0",
+  "foreground": "#181811",
+  "selectionBackground": "#c5a7e0",
+  "cursorColor": "#a0391c",
+  "black": "#393939",
+  "red": "#a01010",
+  "green": "#32582f",
+  "yellow": "#56511d",
+  "blue": "#11508f",
+  "purple": "#6a20c0",
+  "cyan": "#31564c",
+  "white": "#3b3b1c",
+  "brightBlack": "#403832",
+  "brightRed": "#a01010",
+  "brightGreen": "#2f5929",
+  "brightYellow": "#764311",
+  "brightBlue": "#1e556b",
+  "brightPurple": "#691fc2",
+  "brightCyan": "#2f574b",
+  "brightWhite": "#3b3b0c"
+}

--- a/extras/windows-terminal/themes/light/5/oasis_abyss_light_5.json
+++ b/extras/windows-terminal/themes/light/5/oasis_abyss_light_5.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Abyss Light 5",
+  "background": "#c9c9c9",
+  "foreground": "#181811",
+  "selectionBackground": "#aaaaaa",
+  "cursorColor": "#595223",
+  "black": "#2e2e2e",
+  "red": "#8c0e0e",
+  "green": "#2b4d28",
+  "yellow": "#4b4619",
+  "blue": "#0f467c",
+  "purple": "#5d1ba8",
+  "cyan": "#2a4b42",
+  "white": "#2f2f16",
+  "brightBlack": "#332d28",
+  "brightRed": "#8c0e0e",
+  "brightGreen": "#294d24",
+  "brightYellow": "#663a0f",
+  "brightBlue": "#1b4a5d",
+  "brightPurple": "#5c1ca9",
+  "brightCyan": "#294b41",
+  "brightWhite": "#30300a"
+}

--- a/extras/windows-terminal/themes/light/5/oasis_cactus_light_5.json
+++ b/extras/windows-terminal/themes/light/5/oasis_cactus_light_5.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Cactus Light 5",
+  "background": "#c7e5d2",
+  "foreground": "#181811",
+  "selectionBackground": "#9dd2b0",
+  "cursorColor": "#3d683f",
+  "black": "#3c3c3c",
+  "red": "#a51010",
+  "green": "#335b30",
+  "yellow": "#59531d",
+  "blue": "#125393",
+  "purple": "#6d20c7",
+  "cyan": "#32594e",
+  "white": "#3d3d1d",
+  "brightBlack": "#423b33",
+  "brightRed": "#a51010",
+  "brightGreen": "#305c2b",
+  "brightYellow": "#794512",
+  "brightBlue": "#20586f",
+  "brightPurple": "#6c21c7",
+  "brightCyan": "#315a4e",
+  "brightWhite": "#3e3e0d"
+}

--- a/extras/windows-terminal/themes/light/5/oasis_canyon_light_5.json
+++ b/extras/windows-terminal/themes/light/5/oasis_canyon_light_5.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Canyon Light 5",
+  "background": "#e8c3a5",
+  "foreground": "#181811",
+  "selectionBackground": "#dca374",
+  "cursorColor": "#8f3318",
+  "black": "#2e2e2e",
+  "red": "#8d0e0e",
+  "green": "#2c4d29",
+  "yellow": "#4b4619",
+  "blue": "#0f467d",
+  "purple": "#5d1ca9",
+  "cyan": "#2b4c42",
+  "white": "#303017",
+  "brightBlack": "#342e28",
+  "brightRed": "#8d0e0e",
+  "brightGreen": "#294e24",
+  "brightYellow": "#673b0f",
+  "brightBlue": "#1b4b5e",
+  "brightPurple": "#5c1caa",
+  "brightCyan": "#2a4c42",
+  "brightWhite": "#30300a"
+}

--- a/extras/windows-terminal/themes/light/5/oasis_desert_light_5.json
+++ b/extras/windows-terminal/themes/light/5/oasis_desert_light_5.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Desert Light 5",
+  "background": "#ede4b7",
+  "foreground": "#181811",
+  "selectionBackground": "#e1d286",
+  "cursorColor": "#6c621a",
+  "black": "#3f3f3f",
+  "red": "#ab1111",
+  "green": "#365f32",
+  "yellow": "#5c561f",
+  "blue": "#135699",
+  "purple": "#7122ce",
+  "cyan": "#345d51",
+  "white": "#41411f",
+  "brightBlack": "#463e36",
+  "brightRed": "#ab1111",
+  "brightGreen": "#325f2c",
+  "brightYellow": "#7e4812",
+  "brightBlue": "#215b73",
+  "brightPurple": "#7122cf",
+  "brightCyan": "#335d51",
+  "brightWhite": "#41410e"
+}

--- a/extras/windows-terminal/themes/light/5/oasis_dune_light_5.json
+++ b/extras/windows-terminal/themes/light/5/oasis_dune_light_5.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Dune Light 5",
+  "background": "#f2dcba",
+  "foreground": "#181811",
+  "selectionBackground": "#e8c287",
+  "cursorColor": "#695f1a",
+  "black": "#3d3d3d",
+  "red": "#a61010",
+  "green": "#345c30",
+  "yellow": "#5a541e",
+  "blue": "#125495",
+  "purple": "#6e21c8",
+  "cyan": "#335a4f",
+  "white": "#3e3e1d",
+  "brightBlack": "#433b34",
+  "brightRed": "#a61010",
+  "brightGreen": "#315c2b",
+  "brightYellow": "#7a4612",
+  "brightBlue": "#205970",
+  "brightPurple": "#6d21c9",
+  "brightCyan": "#315a4e",
+  "brightWhite": "#3f3f0d"
+}

--- a/extras/windows-terminal/themes/light/5/oasis_lagoon_light_5.json
+++ b/extras/windows-terminal/themes/light/5/oasis_lagoon_light_5.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Lagoon Light 5",
+  "background": "#c1daf6",
+  "foreground": "#181811",
+  "selectionBackground": "#8cbaee",
+  "cursorColor": "#1358ae",
+  "black": "#383838",
+  "red": "#9e0f0f",
+  "green": "#31572e",
+  "yellow": "#554f1c",
+  "blue": "#114f8c",
+  "purple": "#681fbd",
+  "cyan": "#30554a",
+  "white": "#39391b",
+  "brightBlack": "#3e3630",
+  "brightRed": "#9d0f0f",
+  "brightGreen": "#2e5729",
+  "brightYellow": "#734211",
+  "brightBlue": "#1e546a",
+  "brightPurple": "#671fbe",
+  "brightCyan": "#2f554a",
+  "brightWhite": "#3a3a0c"
+}

--- a/extras/windows-terminal/themes/light/5/oasis_luna_light_5.json
+++ b/extras/windows-terminal/themes/light/5/oasis_luna_light_5.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Luna Light 5",
+  "background": "#cbc7f2",
+  "foreground": "#181811",
+  "selectionBackground": "#9d95e6",
+  "cursorColor": "#5a5324",
+  "black": "#303030",
+  "red": "#8f0e0e",
+  "green": "#2c4e29",
+  "yellow": "#4c4819",
+  "blue": "#0f487f",
+  "purple": "#5e1cac",
+  "cyan": "#2b4d43",
+  "white": "#313117",
+  "brightBlack": "#352f29",
+  "brightRed": "#8f0e0e",
+  "brightGreen": "#2a4f25",
+  "brightYellow": "#683c0f",
+  "brightBlue": "#1b4c5f",
+  "brightPurple": "#5e1cac",
+  "brightCyan": "#2a4d43",
+  "brightWhite": "#31310a"
+}

--- a/extras/windows-terminal/themes/light/5/oasis_midnight_light_5.json
+++ b/extras/windows-terminal/themes/light/5/oasis_midnight_light_5.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Midnight Light 5",
+  "background": "#c6cddc",
+  "foreground": "#181811",
+  "selectionBackground": "#a0acc5",
+  "cursorColor": "#5b5424",
+  "black": "#313131",
+  "red": "#910e0e",
+  "green": "#2d4f2a",
+  "yellow": "#4d481a",
+  "blue": "#104880",
+  "purple": "#601cae",
+  "cyan": "#2c4e44",
+  "white": "#323218",
+  "brightBlack": "#362f2a",
+  "brightRed": "#910e0e",
+  "brightGreen": "#2a5025",
+  "brightYellow": "#6a3c0f",
+  "brightBlue": "#1c4d61",
+  "brightPurple": "#5f1dae",
+  "brightCyan": "#2b4e44",
+  "brightWhite": "#32320b"
+}

--- a/extras/windows-terminal/themes/light/5/oasis_mirage_light_5.json
+++ b/extras/windows-terminal/themes/light/5/oasis_mirage_light_5.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Mirage Light 5",
+  "background": "#c1eae6",
+  "foreground": "#181811",
+  "selectionBackground": "#93dbd4",
+  "cursorColor": "#316b5a",
+  "black": "#3e3e3e",
+  "red": "#aa1010",
+  "green": "#355e31",
+  "yellow": "#5c561e",
+  "blue": "#125598",
+  "purple": "#7021cc",
+  "cyan": "#345c50",
+  "white": "#40401e",
+  "brightBlack": "#453d36",
+  "brightRed": "#aa1111",
+  "brightGreen": "#325f2c",
+  "brightYellow": "#7d4712",
+  "brightBlue": "#215a72",
+  "brightPurple": "#6f22cd",
+  "brightCyan": "#325c50",
+  "brightWhite": "#40400e"
+}

--- a/extras/windows-terminal/themes/light/5/oasis_moonlight_light_5.json
+++ b/extras/windows-terminal/themes/light/5/oasis_moonlight_light_5.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Moonlight Light 5",
+  "background": "#ddd8c5",
+  "foreground": "#181811",
+  "selectionBackground": "#c6be9e",
+  "cursorColor": "#635b28",
+  "black": "#383838",
+  "red": "#9e0f0f",
+  "green": "#31572e",
+  "yellow": "#55501c",
+  "blue": "#114f8d",
+  "purple": "#691fbe",
+  "cyan": "#30554b",
+  "white": "#3a3a1b",
+  "brightBlack": "#3e3730",
+  "brightRed": "#9e0f0f",
+  "brightGreen": "#2e5829",
+  "brightYellow": "#744211",
+  "brightBlue": "#1e546a",
+  "brightPurple": "#681fbf",
+  "brightCyan": "#2f564a",
+  "brightWhite": "#3a3a0c"
+}

--- a/extras/windows-terminal/themes/light/5/oasis_night_light_5.json
+++ b/extras/windows-terminal/themes/light/5/oasis_night_light_5.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Night Light 5",
+  "background": "#b7d5f0",
+  "foreground": "#181811",
+  "selectionBackground": "#84b7e6",
+  "cursorColor": "#5e5726",
+  "black": "#343434",
+  "red": "#960f0f",
+  "green": "#2f522b",
+  "yellow": "#504b1b",
+  "blue": "#104b86",
+  "purple": "#631db5",
+  "cyan": "#2d5147",
+  "white": "#353519",
+  "brightBlack": "#3a332d",
+  "brightRed": "#970f0f",
+  "brightGreen": "#2c5327",
+  "brightYellow": "#6e3f10",
+  "brightBlue": "#1d5064",
+  "brightPurple": "#621eb5",
+  "brightCyan": "#2c5146",
+  "brightWhite": "#36360b"
+}

--- a/extras/windows-terminal/themes/light/5/oasis_rose_light_5.json
+++ b/extras/windows-terminal/themes/light/5/oasis_rose_light_5.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Rose Light 5",
+  "background": "#ecbedb",
+  "foreground": "#181811",
+  "selectionBackground": "#de8fc1",
+  "cursorColor": "#8c3156",
+  "black": "#303030",
+  "red": "#8f0e0e",
+  "green": "#2c4e29",
+  "yellow": "#4c4719",
+  "blue": "#0f477f",
+  "purple": "#5e1cab",
+  "cyan": "#2b4d43",
+  "white": "#313117",
+  "brightBlack": "#352e29",
+  "brightRed": "#8f0e0e",
+  "brightGreen": "#2a4f25",
+  "brightYellow": "#683b0f",
+  "brightBlue": "#1b4b5f",
+  "brightPurple": "#5d1cac",
+  "brightCyan": "#2a4d43",
+  "brightWhite": "#31310a"
+}

--- a/extras/windows-terminal/themes/light/5/oasis_scorpion_light_5.json
+++ b/extras/windows-terminal/themes/light/5/oasis_scorpion_light_5.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Scorpion Light 5",
+  "background": "#efbaa9",
+  "foreground": "#181811",
+  "selectionBackground": "#e59175",
+  "cursorColor": "#564f22",
+  "black": "#2c2c2c",
+  "red": "#880d0d",
+  "green": "#2a4a27",
+  "yellow": "#484418",
+  "blue": "#0f4478",
+  "purple": "#5a1ba3",
+  "cyan": "#29493f",
+  "white": "#2d2d15",
+  "brightBlack": "#302b25",
+  "brightRed": "#880d0d",
+  "brightGreen": "#284b23",
+  "brightYellow": "#63390f",
+  "brightBlue": "#1a485b",
+  "brightPurple": "#591ba4",
+  "brightCyan": "#28493f",
+  "brightWhite": "#2d2d0a"
+}

--- a/extras/windows-terminal/themes/light/5/oasis_sol_light_5.json
+++ b/extras/windows-terminal/themes/light/5/oasis_sol_light_5.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Sol Light 5",
+  "background": "#ecabab",
+  "foreground": "#181811",
+  "selectionBackground": "#e17979",
+  "cursorColor": "#891f21",
+  "black": "#232323",
+  "red": "#7b0c0c",
+  "green": "#254223",
+  "yellow": "#413c15",
+  "blue": "#0d3d6c",
+  "purple": "#511893",
+  "cyan": "#254139",
+  "white": "#242411",
+  "brightBlack": "#27221e",
+  "brightRed": "#7b0c0c",
+  "brightGreen": "#23431f",
+  "brightYellow": "#59330d",
+  "brightBlue": "#174051",
+  "brightPurple": "#501893",
+  "brightCyan": "#244139",
+  "brightWhite": "#252508"
+}

--- a/extras/windows-terminal/themes/light/5/oasis_starlight_light_5.json
+++ b/extras/windows-terminal/themes/light/5/oasis_starlight_light_5.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Starlight Light 5",
+  "background": "#ebe5d5",
+  "foreground": "#181811",
+  "selectionBackground": "#d7cbac",
+  "cursorColor": "#6c642b",
+  "black": "#404040",
+  "red": "#ae1111",
+  "green": "#366033",
+  "yellow": "#5e581f",
+  "blue": "#13579b",
+  "purple": "#7322d1",
+  "cyan": "#355e52",
+  "white": "#42421f",
+  "brightBlack": "#473f37",
+  "brightRed": "#ae1111",
+  "brightGreen": "#33612d",
+  "brightYellow": "#804913",
+  "brightBlue": "#225d75",
+  "brightPurple": "#7222d2",
+  "brightCyan": "#345e52",
+  "brightWhite": "#43430e"
+}

--- a/extras/windows-terminal/themes/light/5/oasis_twilight_light_5.json
+++ b/extras/windows-terminal/themes/light/5/oasis_twilight_light_5.json
@@ -1,0 +1,23 @@
+{
+  "name": "Oasis Twilight Light 5",
+  "background": "#dbc8ec",
+  "foreground": "#181811",
+  "selectionBackground": "#bd9bdc",
+  "cursorColor": "#953519",
+  "black": "#323232",
+  "red": "#940e0e",
+  "green": "#2e512b",
+  "yellow": "#4f4a1a",
+  "blue": "#104a83",
+  "purple": "#621db1",
+  "cyan": "#2d4f45",
+  "white": "#343418",
+  "brightBlack": "#38312b",
+  "brightRed": "#940e0e",
+  "brightGreen": "#2b5126",
+  "brightYellow": "#6c3e10",
+  "brightBlue": "#1c4e63",
+  "brightPurple": "#611db2",
+  "brightCyan": "#2c5045",
+  "brightWhite": "#34340b"
+}


### PR DESCRIPTION
## Summary

Closes #26. Adds two new extras generators, covering every Oasis palette (dark + light intensities 1-5), not just Mirage as originally requested:

- `extras/windows-terminal`: flat JSON color-scheme objects, one per palette variant, ready to paste into Windows Terminal's `settings.json` `schemes` array. Maps `palette.terminal.magenta`/`bright_magenta` to Windows Terminal's own `purple`/`brightPurple` field names.
- `extras/psreadline`: `Set-PSReadLineOption -Colors @{ ... }` scripts using 24-bit ANSI truecolor escapes, mapping PSReadLine's syntax roles (Command, Parameter, String, Variable, etc.) onto the Oasis syntax palette. `Selection`/`ListPredictionSelected` use plain reverse video so they stay legible on every variant, matching what the issue reporter had already proposed.

Both generators follow the existing extras conventions (`Utils.for_each_palette_variant`, `Utils.build_variant_path`) and are auto-discovered by `extras/run_all_generators.lua` — no registration needed. The extras table in the root `README.md` gained two rows; since "Windows Terminal" is wider than any prior entry, the whole table's column padding was re-flowed to stay aligned, which is why every row in that table shows as changed.

## Codex review

Ran `codex exec --sandbox read-only` against the diff. Findings and how they were handled:

- **Medium — PowerShell 5.1 incompatible with the `` `e `` escape sequence used in generated scripts.** Valid: `` `e `` requires PowerShell 6+/pwsh; Windows PowerShell 5.1 (still the Windows default) doesn't parse it. Fixed by adding a note to `extras/psreadline/README.md` documenting the PowerShell 7+ requirement and the `$([char]27)` workaround for 5.1.
- **Low — Windows Terminal generator didn't JSON-escape field values.** Valid robustness gap (palette names/hex values are always safe today, but a future value with a quote would break the JSON). Fixed by routing values through `ColorUtils.json_escape`, the same helper other generators already use.
- **Low — `Command` mapped to `palette.syntax.statement` rather than `palette.syntax.func`.** Rejected: this was a deliberate mapping — PowerShell commands/cmdlets read more like the invoked-verb role (`statement`) than a function definition, and it mirrors the Yellow-for-Command choice in the issue reporter's own example.
- **Low — README table reformat touches every row, not just the new ones.** Rejected: the table is a manually-aligned markdown table throughout the file; re-flowing padding when a longer entry is added is consistent with the existing style, not diff noise from a bug.

## Test plan

- [x] `lua extras/windows-terminal/generate_windowsterminal.lua` — 96/96 variants generated, 0 errors
- [x] `lua extras/psreadline/generate_psreadline.lua` — 96/96 variants generated, 0 errors
- [x] Spot-checked generated JSON with `python3 -m json.load` — valid
- [x] `stylua --check` on both new generator scripts — clean