### PR TITLE
fix: upload thunderbird .xpi themes to releases

### DIFF
--- a/.github/workflows/release-thunderbird.yml
+++ b/.github/workflows/release-thunderbird.yml
@@ -1,0 +1,41 @@
+name: Release Thunderbird themes
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to upload the .xpi assets to
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-upload:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install lua and zip
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y lua5.4 zip
+          sudo ln -sf /usr/bin/lua5.4 /usr/local/bin/lua
+
+      - name: Build .xpi themes
+        run: lua extras/thunderbird/generate_thunderbird.lua
+
+      - name: Upload .xpi assets to the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: |
+          mapfile -t assets < <(find extras/thunderbird/themes -name '*.xpi' | sort)
+          if [ ${#assets[@]} -eq 0 ]; then
+            echo "No .xpi files were generated"
+            exit 1
+          fi
+          echo "Uploading ${#assets[@]} assets to $TAG"
+          gh release upload "$TAG" "${assets[@]}" --clobber

--- a/extras/thunderbird/README.md
+++ b/extras/thunderbird/README.md
@@ -4,10 +4,10 @@ Oasis color themes for Mozilla Thunderbird, packaged as WebExtension themes.
 
 ## Installation
 
-`.xpi` files are not committed to this repository. Get one from the GitHub release assets, or build it yourself:
+`.xpi` files are not committed to this repository. Get one from the latest GitHub release assets, or you can build it yourself:
 
 ```bash
-just extra thunderbird
+lua extras/thunderbird/generate_thunderbird.lua
 ```
 
 1. Download your preferred `.xpi` theme file from the release assets (or `themes/` after building locally)
@@ -30,11 +30,3 @@ just extra thunderbird
 1. Go to **Tools** → **Add-ons and Themes**
 2. Find the Oasis theme in the **Themes** section
 3. Click **Remove** or **Disable**
-
-## Development
-
-To regenerate all themes:
-
-```bash
-lua extras/thunderbird/generate_thunderbird.lua
-```


### PR DESCRIPTION
The Thunderbird README tells people to grab a `.xpi` from the release assets, this adds `.github/workflows/release-thunderbird.yml`, which installs `lua5.4` and `zip`, runs the generator, and uploads the `.xpi` files with `gh release upload --clobber`. It fires on `release: published`, and also takes a `tag` input via `workflow_dispatch` so older releases can be filled in.

No generator or README changes.

Checked locally: 96 `.xpi` (16 dark, 80 light), no errors, and regenerating is a byte-identical no-op so nothing else shows up in `git status`. The basenames are unique across `themes/dark/` and `themes/light/<1-5>/`.

Once this is merged, run:

```bash
gh workflow run release-thunderbird.yml -f tag=v6.1.1
```