### PR TITLE
fix: ship thunderbird themes as one release zip

### DIFF
--- a/.github/workflows/release-thunderbird.yml
+++ b/.github/workflows/release-thunderbird.yml
@@ -27,15 +27,19 @@ jobs:
       - name: Build .xpi themes
         run: lua extras/thunderbird/generate_thunderbird.lua
 
-      - name: Upload .xpi assets to the release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          TAG: ${{ github.event.release.tag_name || inputs.tag }}
+      - name: Bundle the themes
         run: |
-          mapfile -t assets < <(find extras/thunderbird/themes -name '*.xpi' | sort)
-          if [ ${#assets[@]} -eq 0 ]; then
+          count=$(find extras/thunderbird/themes -name '*.xpi' | wc -l)
+          if [ "$count" -eq 0 ]; then
             echo "No .xpi files were generated"
             exit 1
           fi
-          echo "Uploading ${#assets[@]} assets to $TAG"
-          gh release upload "$TAG" "${assets[@]}" --clobber
+          echo "Bundling $count themes"
+          cd extras/thunderbird
+          zip -qr -X "$GITHUB_WORKSPACE/oasis-thunderbird-themes.zip" themes
+
+      - name: Upload the bundle to the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: gh release upload "$TAG" oasis-thunderbird-themes.zip --clobber

--- a/extras/thunderbird/README.md
+++ b/extras/thunderbird/README.md
@@ -4,22 +4,23 @@ Oasis color themes for Mozilla Thunderbird, packaged as WebExtension themes.
 
 ## Installation
 
-`.xpi` files are not committed to this repository. Get one from the latest GitHub release assets, or you can build it yourself:
+`.xpi` files are not committed to this repository. Download `oasis-thunderbird-themes.zip` from the latest GitHub release assets, or you can build them yourself:
 
 ```bash
 lua extras/thunderbird/generate_thunderbird.lua
 ```
 
-1. Download your preferred `.xpi` theme file from the release assets (or `themes/` after building locally)
+1. Download and extract `oasis-thunderbird-themes.zip` (or use `themes/` after building locally)
 2. Open Thunderbird
 3. Go to **Tools** → **Add-ons and Themes** (or press `Ctrl+Shift+A`)
 4. Click the gear icon ⚙️ and select **Install Add-on From File...**
-5. Navigate to and select the downloaded `.xpi` file
+5. Navigate to and select your preferred `.xpi` file
 6. Click **Add** to install the theme
 7. The theme will be applied automatically
 
 ## Available Themes
 
+- The release zip and a local build share the same layout, rooted at `themes/`.
 - Dark variants live in `themes/dark/` as `oasis_<palette>_dark.xpi`.
 - Light variants are grouped under `themes/light/<1-5>/` as `oasis_<palette>_light_<intensity>.xpi`.
 - Palettes: abyss, cactus, canyon, desert, dune, lagoon, luna, midnight, mirage, moonlight, night, rose, scorpion, sol, starlight, twilight

--- a/extras/thunderbird/generate_thunderbird.lua
+++ b/extras/thunderbird/generate_thunderbird.lua
@@ -330,17 +330,17 @@ local function main()
       "",
       "## Installation",
       "",
-      "`.xpi` files are not committed to this repository. Get one from the GitHub release assets, or build it yourself:",
+      "`.xpi` files are not committed to this repository. Download `oasis-thunderbird-themes.zip` from the latest GitHub release assets, or you can build them yourself:",
       "",
       "```bash",
-      "just extra thunderbird",
+      "lua extras/thunderbird/generate_thunderbird.lua",
       "```",
       "",
-      "1. Download your preferred `.xpi` theme file from the release assets (or `themes/` after building locally)",
+      "1. Download and extract `oasis-thunderbird-themes.zip` (or use `themes/` after building locally)",
       "2. Open Thunderbird",
       "3. Go to **Tools** → **Add-ons and Themes** (or press `Ctrl+Shift+A`)",
       "4. Click the gear icon ⚙️ and select **Install Add-on From File...**",
-      "5. Navigate to and select the downloaded `.xpi` file",
+      "5. Navigate to and select your preferred `.xpi` file",
       "6. Click **Add** to install the theme",
       "7. The theme will be applied automatically",
       "",
@@ -354,6 +354,10 @@ local function main()
     end
     table.sort(palette_list)
 
+    table.insert(
+      readme_lines,
+      "- The release zip and a local build share the same layout, rooted at `themes/`."
+    )
     table.insert(readme_lines, "- Dark variants live in `themes/dark/` as `oasis_<palette>_dark.xpi`.")
     table.insert(
       readme_lines,
@@ -371,14 +375,6 @@ local function main()
     table.insert(readme_lines, "1. Go to **Tools** → **Add-ons and Themes**")
     table.insert(readme_lines, "2. Find the Oasis theme in the **Themes** section")
     table.insert(readme_lines, "3. Click **Remove** or **Disable**")
-    table.insert(readme_lines, "")
-    table.insert(readme_lines, "## Development")
-    table.insert(readme_lines, "")
-    table.insert(readme_lines, "To regenerate all themes:")
-    table.insert(readme_lines, "")
-    table.insert(readme_lines, "```bash")
-    table.insert(readme_lines, "lua extras/thunderbird/generate_thunderbird.lua")
-    table.insert(readme_lines, "```")
     table.insert(readme_lines, "")
 
     local readme_content = table.concat(readme_lines, "\n")


### PR DESCRIPTION
Follow-up to #54. Uploading all 96 `.xpi` files as separate assets works, but it buries everything else on the release page.

This bundles `themes/` into a single `oasis-thunderbird-themes.zip` and uploads that instead. It's 2.1 MB, and the layout inside matches a local build (`themes/dark/`, `themes/light/<1-5>/`), so the instructions are the same either way.

Also folds the README wording back into `generate_thunderbird.lua`. Forgot the README is generated, so the hand edit on `main` got overwritten on rebuild.

Built locally: 96 `.xpi` into a 2.1 MB zip, and regenerating twice leaves the tree clean.